### PR TITLE
Schema macro rewrite

### DIFF
--- a/CS2Fixes.vcxproj.filters
+++ b/CS2Fixes.vcxproj.filters
@@ -154,9 +154,6 @@
     <ClInclude Include="src\commands.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\cs2_sdk\entity\ccsweaponbase.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="src\cdetour.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -177,6 +174,9 @@
     </ClInclude>
     <ClInclude Include="src\adminsystem.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cs2_sdk\entity\ccsweaponbase.h">
+      <Filter>Header Files\cs2_sdk\entity</Filter>
     </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -71,9 +71,9 @@ CON_COMMAND_CHAT(ban, "ban a player")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 
-	ZEPlayer* pPlayer = g_playerManager->GetPlayer(player->entindex() - 1);
+	ZEPlayer *pPlayer = g_playerManager->GetPlayer(iCommandPlayer);
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_BAN))
 	{
@@ -129,7 +129,7 @@ CON_COMMAND_CHAT(ban, "ban a player")
 		infraction->ApplyInfraction(pTargetPlayer);
 		g_pAdminSystem->SaveInfractions();
 
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have banned %s for %i minutes.", pTarget->m_iszPlayerName(), iDuration);
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have banned %s for %i minutes.", pTarget->GetPlayerName(), iDuration);
 	}
 }
 
@@ -192,7 +192,7 @@ CON_COMMAND_CHAT(mute, "mutes a player")
 		infraction->ApplyInfraction(pTargetPlayer);
 		g_pAdminSystem->SaveInfractions();
 
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have muted %s for %i mins.", pTarget->m_iszPlayerName(), iDuration);
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have muted %s for %i mins.", pTarget->GetPlayerName(), iDuration);
 	}
 }
 
@@ -201,9 +201,9 @@ CON_COMMAND_CHAT(kick, "kick a player")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 
-	ZEPlayer* pPlayer = g_playerManager->GetPlayer(player->entindex() - 1);
+	ZEPlayer* pPlayer = g_playerManager->GetPlayer(player->GetPlayerSlot());
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_KICK))
 	{
@@ -239,7 +239,7 @@ CON_COMMAND_CHAT(kick, "kick a player")
 		
 		g_pEngineServer2->DisconnectClient(pTargetPlayer->GetPlayerSlot().Get(), NETWORK_DISCONNECT_KICKED);
 
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have kicked %s.", pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have kicked %s.", pTarget->GetPlayerName());
 	}
 }
 
@@ -248,9 +248,9 @@ CON_COMMAND_CHAT(slay, "slay a player")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 
-	ZEPlayer *pPlayer = g_playerManager->GetPlayer(player->entindex() - 1);
+	ZEPlayer *pPlayer = g_playerManager->GetPlayer(player->GetPlayerSlot());
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_SLAY))
 	{
@@ -285,7 +285,7 @@ CON_COMMAND_CHAT(slay, "slay a player")
 		// CBasePlayerPawn::CommitSuicide(bool bExplode, bool bForce)
 		CALL_VIRTUAL(void, 354, pTarget->GetPawn(), false, true);
 
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Brought %s.", pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Brought %s.", pTarget->GetPlayerName());
 	}
 }
 
@@ -294,7 +294,7 @@ CON_COMMAND_CHAT(map, "change map")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 
 	ZEPlayer *pPlayer = g_playerManager->GetPlayer(iCommandPlayer);
 

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -77,13 +77,13 @@ CON_COMMAND_CHAT(ban, "ban a player")
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_BAN))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You don't have access to this command.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You don't have access to this command.");
 		return;
 	}
 
 	if (args.ArgC() < 3)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Usage: !ban <name> <duration/0 (permanent)>");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Usage: !ban <name> <duration/0 (permanent)>");
 		return;
 	}
 
@@ -92,13 +92,13 @@ CON_COMMAND_CHAT(ban, "ban a player")
 
 	if (g_playerManager->TargetPlayerString(iCommandPlayer, args[1], iNumClients, pSlot) != ETargetType::PLAYER || iNumClients > 1)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Target too ambiguous.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Target too ambiguous.");
 		return;
 	}
 
 	if (!iNumClients)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Target not found.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Target not found.");
 		return;
 	}
 
@@ -107,7 +107,7 @@ CON_COMMAND_CHAT(ban, "ban a player")
 
 	if (*end)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Invalid duration.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Invalid duration.");
 		return;
 	}
 
@@ -129,7 +129,7 @@ CON_COMMAND_CHAT(ban, "ban a player")
 		infraction->ApplyInfraction(pTargetPlayer);
 		g_pAdminSystem->SaveInfractions();
 
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have banned %s for %i mins.", &pTarget->m_iszPlayerName(), iDuration);
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have banned %s for %i minutes.", pTarget->m_iszPlayerName(), iDuration);
 	}
 }
 
@@ -138,19 +138,19 @@ CON_COMMAND_CHAT(mute, "mutes a player")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 
-	ZEPlayer* pPlayer = g_playerManager->GetPlayer(player->entindex() - 1);
+	ZEPlayer* pPlayer = g_playerManager->GetPlayer(player->GetPlayerSlot());
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_BAN))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You don't have access to this command.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You don't have access to this command.");
 		return;
 	}
 
 	if (args.ArgC() < 3)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Usage: !mute <name> <duration/0 (permanent)>");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Usage: !mute <name> <duration/0 (permanent)>");
 		return;
 	}
 
@@ -161,7 +161,7 @@ CON_COMMAND_CHAT(mute, "mutes a player")
 
 	if (!iNumClients)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Target not found.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Target not found.");
 		return;
 	}
 
@@ -170,7 +170,7 @@ CON_COMMAND_CHAT(mute, "mutes a player")
 
 	if (*end)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Invalid duration.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Invalid duration.");
 		return;
 	}
 
@@ -192,7 +192,7 @@ CON_COMMAND_CHAT(mute, "mutes a player")
 		infraction->ApplyInfraction(pTargetPlayer);
 		g_pAdminSystem->SaveInfractions();
 
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have muted %s for %i mins.", &pTarget->m_iszPlayerName(), iDuration);
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have muted %s for %i mins.", pTarget->m_iszPlayerName(), iDuration);
 	}
 }
 
@@ -207,13 +207,13 @@ CON_COMMAND_CHAT(kick, "kick a player")
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_KICK))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You don't have access to this command.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You don't have access to this command.");
 		return;
 	}
 
 	if (args.ArgC() < 2)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Usage: !kick <name>");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Usage: !kick <name>");
 		return;
 	}
 
@@ -224,7 +224,7 @@ CON_COMMAND_CHAT(kick, "kick a player")
 
 	if (!iNumClients)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Target not found.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Target not found.");
 		return;
 	}
 
@@ -239,7 +239,7 @@ CON_COMMAND_CHAT(kick, "kick a player")
 		
 		g_pEngineServer2->DisconnectClient(pTargetPlayer->GetPlayerSlot().Get(), NETWORK_DISCONNECT_KICKED);
 
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have kicked %s.", &pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have kicked %s.", pTarget->m_iszPlayerName());
 	}
 }
 
@@ -254,13 +254,13 @@ CON_COMMAND_CHAT(slay, "slay a player")
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_SLAY))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You don't have access to this command.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You don't have access to this command.");
 		return;
 	}
 
 	if (args.ArgC() < 2)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Usage: !slay <name>");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !bring <name>");
 		return;
 	}
 
@@ -271,7 +271,7 @@ CON_COMMAND_CHAT(slay, "slay a player")
 
 	if (!iNumClients)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Target not found.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Target not found.");
 		return;
 	}
 
@@ -285,7 +285,7 @@ CON_COMMAND_CHAT(slay, "slay a player")
 		// CBasePlayerPawn::CommitSuicide(bool bExplode, bool bForce)
 		CALL_VIRTUAL(void, 354, pTarget->GetPawn(), false, true);
 
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Slayed %s.", &pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Brought %s.", pTarget->m_iszPlayerName());
 	}
 }
 
@@ -300,19 +300,19 @@ CON_COMMAND_CHAT(map, "change map")
 
 	if (!pPlayer->IsAdminFlagSet(ADMFLAG_CHANGEMAP))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You don't have access to this command.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You don't have access to this command.");
 		return;
 	}
 
 	if (args.ArgC() < 2)
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Usage: !map <mapname>");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Usage: !map <mapname>");
 		return;
 	}
 
 	if (!g_pEngineServer2->IsMapValid(args[1]))
 	{
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Invalid map specified");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Invalid map specified.");
 		return;
 	}
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -146,14 +146,14 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 	if (!player)
 		return;
 
-	int iPlayer = player->entindex() - 1;
+	int iPlayer = player->GetPlayerSlot();
 
 	ZEPlayer *pZEPlayer = g_playerManager->GetPlayer(iPlayer);
 
 	// Something has to really go wrong for this to happen
 	if (!pZEPlayer)
 	{
-		Warning("%s Tried to access a null ZEPlayer!!\n", player->m_iszPlayerName());
+		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
 		return;
 	}
 
@@ -195,7 +195,7 @@ CON_COMMAND_CHAT(message, "message someone")
 	const char *pMessage = args.ArgS() + V_strlen(args[1]) + 1;
 
 	char buf[256];
-	V_snprintf(buf, sizeof(buf), CHAT_PREFIX"Private message from %s to %s: \5%s", &player->m_iszPlayerName(), &target->m_iszPlayerName(), pMessage);
+	V_snprintf(buf, sizeof(buf), CHAT_PREFIX"Private message from %s to %s: \5%s", player->GetPlayerName(), target->GetPlayerName(), pMessage);
 
 	CSingleRecipientFilter filter(uid);
 
@@ -221,7 +221,7 @@ CON_COMMAND_CHAT(test_target, "test string targetting")
 	if (!player)
 		return;
 
-	int iCommandPlayer = player->entindex() - 1;
+	int iCommandPlayer = player->GetPlayerSlot();
 	int iNumClients = 0;
 	int pSlots[MAXPLAYERS];
 
@@ -234,8 +234,8 @@ CON_COMMAND_CHAT(test_target, "test string targetting")
 		if (!pTarget)
 			continue;
 
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Targeting %s", &pTarget->m_iszPlayerName());
-		Message("Targeting %s\n", &pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Targeting %s", pTarget->GetPlayerName());
+		Message("Targeting %s\n", pTarget->GetPlayerName());
 	}
 }
 
@@ -288,7 +288,7 @@ CON_COMMAND_CHAT(setkills, "set your kills")
 	if (!player)
 		return;
 
-	player->m_pActionTrackingServices->m_matchStats.Get().m_iKills = atoi(args[1]);
+	player->m_pActionTrackingServices->m_matchStats().m_iKills = atoi(args[1]);
 
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have set your kills to %d.", atoi(args[1]));
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -82,11 +82,11 @@ void ParseWeaponCommand(CCSPlayerController *pController, const char *pszWeaponN
 
 		if (!V_stricmp(pszWeaponName, weaponEntry.command))
 		{
-			CCSPlayer_ItemServices *pItemServices = pController->m_hPawn()->m_pItemServices();
-			int money = pController->m_pInGameMoneyServices()->m_iAccount();
+			CCSPlayer_ItemServices *pItemServices = pController->GetPawn()->m_pItemServices;
+			int money = pController->m_pInGameMoneyServices->m_iAccount;
 			if (money >= weaponEntry.iPrice)
 			{
-				pController->m_pInGameMoneyServices()->m_iAccount(money - weaponEntry.iPrice);
+				pController->m_pInGameMoneyServices->m_iAccount = money - weaponEntry.iPrice;
 				pItemServices->GiveNamedItem(weaponEntry.szWeaponName);
 			}
 
@@ -173,9 +173,9 @@ CON_COMMAND_CHAT(takemoney, "take your money")
 		return;
 
 	int amount = atoi(args[1]);
-	int money = player->m_pInGameMoneyServices()->m_iAccount();
+	int money = player->m_pInGameMoneyServices->m_iAccount;
 
-	player->m_pInGameMoneyServices()->m_iAccount(money - amount);
+	player->m_pInGameMoneyServices->m_iAccount = money - amount;
 }
 
 CON_COMMAND_CHAT(message, "message someone")
@@ -209,7 +209,11 @@ CON_COMMAND_CHAT(sethealth, "set your health")
 
 	int health = atoi(args[1]);
 
-	player->m_hPawn()->m_iHealth(health);
+	Z_CBaseEntity *pEnt = (Z_CBaseEntity *)player->GetPawn();
+
+	pEnt->m_iHealth = health;
+
+	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Your health is now %d", health);
 }
 
 CON_COMMAND_CHAT(test_target, "test string targetting")
@@ -240,7 +244,7 @@ CON_COMMAND_CHAT(getorigin, "get your origin")
 	if (!player)
 		return;
 
-	Vector vecAbsOrigin = player->m_hPawn()->GetAbsOrigin();
+	Vector vecAbsOrigin = player->GetPawn()->GetAbsOrigin();
 
 	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Your origin is %f %f %f", vecAbsOrigin.x, vecAbsOrigin.y, vecAbsOrigin.z);
 }
@@ -250,8 +254,7 @@ CON_COMMAND_CHAT(setorigin, "set your origin")
 	if (!player)
 		return;
 
-	CBasePlayerPawn *pPawn = player->m_hPawn();
-
+	CBasePlayerPawn *pPawn = player->GetPawn();
 	Vector vecNewOrigin;
 	V_StringToVector(args.ArgS(), vecNewOrigin);
 
@@ -265,7 +268,7 @@ CON_COMMAND_CHAT(getstats, "get your stats")
 	if (!player)
 		return;
 
-	CSMatchStats_t stats = player->m_pActionTrackingServices()->m_matchStats();
+	CSMatchStats_t stats = player->m_pActionTrackingServices->m_matchStats;
 
 	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Kills: %d", stats.m_iKills());
 	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Deaths: %d", stats.m_iDeaths());
@@ -278,7 +281,7 @@ CON_COMMAND_CHAT(setkills, "set your kills")
 	if (!player)
 		return;
 
-	player->m_pActionTrackingServices()->m_matchStats().m_iKills(atoi(args[1]));
+	player->m_pActionTrackingServices->m_matchStats.Get().m_iKills = atoi(args[1]);
 
 	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have set your kills to %d.", atoi(args[1]));
 }
@@ -302,8 +305,8 @@ void FixWeapon(CCSWeaponBase *pWeapon)
 				pWeapon->m_AttributeManager().m_Item().m_iItemDefinitionIndex(),
 				pWeapon->m_AttributeManager().m_Item().m_bInitialized());
 
-			pWeapon->m_AttributeManager().m_Item().m_bInitialized(true);
-			pWeapon->m_AttributeManager().m_Item().m_iItemDefinitionIndex(WeaponMap[i].iItemDefIndex);
+			pWeapon->m_AttributeManager().m_Item().m_bInitialized = true;
+			pWeapon->m_AttributeManager().m_Item().m_iItemDefinitionIndex = WeaponMap[i].iItemDefIndex;
 		}
 	}
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -159,7 +159,7 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 
 	pZEPlayer->ToggleStopSound();
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have toggled weapon effects.");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have toggled weapon effects.");
 }
 
 CON_COMMAND_CHAT(say, "say something using console")
@@ -195,7 +195,7 @@ CON_COMMAND_CHAT(message, "message someone")
 	const char *pMessage = args.ArgS() + V_strlen(args[1]) + 1;
 
 	char buf[256];
-	V_snprintf(buf, sizeof(buf), " \7[CS2Fixes]\1 Private message from %s to %s: \5%s", &player->m_iszPlayerName(), &target->m_iszPlayerName(), pMessage);
+	V_snprintf(buf, sizeof(buf), CHAT_PREFIX"Private message from %s to %s: \5%s", &player->m_iszPlayerName(), &target->m_iszPlayerName(), pMessage);
 
 	CSingleRecipientFilter filter(uid);
 
@@ -213,7 +213,7 @@ CON_COMMAND_CHAT(sethealth, "set your health")
 
 	pEnt->m_iHealth = health;
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Your health is now %d", health);
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Your health is now %d", health);
 }
 
 CON_COMMAND_CHAT(test_target, "test string targetting")
@@ -234,7 +234,7 @@ CON_COMMAND_CHAT(test_target, "test string targetting")
 		if (!pTarget)
 			continue;
 
-		ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Targeting %s", &pTarget->m_iszPlayerName());
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Targeting %s", &pTarget->m_iszPlayerName());
 		Message("Targeting %s\n", &pTarget->m_iszPlayerName());
 	}
 }
@@ -246,7 +246,7 @@ CON_COMMAND_CHAT(getorigin, "get your origin")
 
 	Vector vecAbsOrigin = player->GetPawn()->GetAbsOrigin();
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Your origin is %f %f %f", vecAbsOrigin.x, vecAbsOrigin.y, vecAbsOrigin.z);
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Your origin is %f %f %f", vecAbsOrigin.x, vecAbsOrigin.y, vecAbsOrigin.z);
 }
 
 CON_COMMAND_CHAT(setorigin, "set your origin")
@@ -260,7 +260,7 @@ CON_COMMAND_CHAT(setorigin, "set your origin")
 
 	pPawn->SetAbsOrigin(vecNewOrigin);
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Your origin is now %f %f %f", vecNewOrigin.x, vecNewOrigin.y, vecNewOrigin.z);
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Your origin is now %f %f %f", vecNewOrigin.x, vecNewOrigin.y, vecNewOrigin.z);
 }
 
 CON_COMMAND_CHAT(getstats, "get your stats")
@@ -268,12 +268,19 @@ CON_COMMAND_CHAT(getstats, "get your stats")
 	if (!player)
 		return;
 
-	CSMatchStats_t stats = player->m_pActionTrackingServices->m_matchStats;
+	CSMatchStats_t *stats = &player->m_pActionTrackingServices->m_matchStats();
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Kills: %d", stats.m_iKills());
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Deaths: %d", stats.m_iDeaths());
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Assists: %d", stats.m_iAssists());
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 Damage: %d", stats.m_iDamage());
+	ClientPrint(player, HUD_PRINTCENTER, 
+		"Kills: %i\n"
+		"Deaths: %i\n"
+		"Assists: %i\n"
+		"Damage: %i"
+		, stats->m_iKills.Get(), stats->m_iDeaths.Get(), stats->m_iAssists.Get(), stats->m_iDamage.Get());
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Kills: %d", stats->m_iKills.Get());
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Deaths: %d", stats->m_iDeaths.Get());
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Assists: %d", stats->m_iAssists.Get());
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"Damage: %d", stats->m_iDamage.Get());
 }
 
 CON_COMMAND_CHAT(setkills, "set your kills")
@@ -283,7 +290,7 @@ CON_COMMAND_CHAT(setkills, "set your kills")
 
 	player->m_pActionTrackingServices->m_matchStats.Get().m_iKills = atoi(args[1]);
 
-	ClientPrint(player, HUD_PRINTTALK, " \7[CS2Fixes]\1 You have set your kills to %d.", atoi(args[1]));
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have set your kills to %d.", atoi(args[1]));
 }
 
 // Lookup a weapon classname in the weapon map and "initialize" it.
@@ -301,7 +308,7 @@ void FixWeapon(CCSWeaponBase *pWeapon)
 	{
 		if (!V_stricmp(WeaponMap[i].szWeaponName, pszClassName))
 		{
-			Message("Fixing a %s with index = %d and initialized = %d\n", pszClassName,
+			DevMsg("Fixing a %s with index = %d and initialized = %d\n", pszClassName,
 				pWeapon->m_AttributeManager().m_Item().m_iItemDefinitionIndex(),
 				pWeapon->m_AttributeManager().m_Item().m_bInitialized());
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -22,6 +22,7 @@
 #include "convar.h"
 
 #define COMMAND_PREFIX "c_"
+#define CHAT_PREFIX	" \7[CS2Fixes]\1 "
 
 typedef void (*FnChatCommandCallback_t)(const CCommand &args, CCSPlayerController *player);
 

--- a/src/cs2_sdk/entity/cbaseentity.h
+++ b/src/cs2_sdk/entity/cbaseentity.h
@@ -26,6 +26,12 @@
 
 CGlobalVars* GetGameGlobals();
 
+class CNetworkTransmitComponent
+{
+public:
+	DECLARE_SCHEMA_CLASS_INLINE(CNetworkTransmitComponent)
+};
+
 class CNetworkOriginCellCoordQuantizedVector
 {
 public:
@@ -114,7 +120,7 @@ public:
 	SCHEMA_FIELD(CBodyComponent *, m_CBodyComponent)
 	SCHEMA_FIELD(CBitVec<64>, m_isSteadyState)
 	SCHEMA_FIELD(float, m_lastNetworkChange)
-	PSCHEMA_FIELD(void*, m_NetworkTransmitComponent)
+	SCHEMA_FIELD_POINTER(CNetworkTransmitComponent, m_NetworkTransmitComponent)
 	SCHEMA_FIELD(int, m_iHealth)
 	SCHEMA_FIELD(int, m_iTeamNum)
 	SCHEMA_FIELD(Vector, m_vecBaseVelocity)
@@ -126,7 +132,6 @@ public:
 	int entindex() { return m_pEntity->m_EHandle.GetEntryIndex(); }
 
 	Vector GetAbsOrigin() { return m_CBodyComponent->m_pSceneNode->m_vecAbsOrigin; }
-
 	void SetAbsOrigin(Vector vecOrigin) { m_CBodyComponent->m_pSceneNode->m_vecAbsOrigin = vecOrigin; }
 
 	void Teleport(Vector *position, QAngle *angles, Vector *velocity) { CALL_VIRTUAL(void, 148, this, position, angles, velocity); }

--- a/src/cs2_sdk/entity/cbaseentity.h
+++ b/src/cs2_sdk/entity/cbaseentity.h
@@ -106,7 +106,10 @@ public:
 class Z_CBaseEntity : public CBaseEntity
 {
 public:
-	DECLARE_SCHEMA_CLASS(CBaseEntity)
+	// This is a unique case as CBaseEntity is already defined in the sdk
+	typedef Z_CBaseEntity ThisClass;
+	static constexpr const char *ThisClassName = "CBaseEntity";
+	static constexpr bool IsStruct = false;
 
 	SCHEMA_FIELD(CBodyComponent *, m_CBodyComponent)
 	SCHEMA_FIELD(CBitVec<64>, m_isSteadyState)
@@ -122,9 +125,9 @@ public:
 
 	int entindex() { return m_pEntity->m_EHandle.GetEntryIndex(); }
 
-	Vector GetAbsOrigin() { return m_CBodyComponent()->m_pSceneNode()->m_vecAbsOrigin(); }
+	Vector GetAbsOrigin() { return m_CBodyComponent->m_pSceneNode->m_vecAbsOrigin; }
 
-	void SetAbsOrigin(Vector vecOrigin) { m_CBodyComponent()->m_pSceneNode()->m_vecAbsOrigin(vecOrigin); }
+	void SetAbsOrigin(Vector vecOrigin) { m_CBodyComponent->m_pSceneNode->m_vecAbsOrigin = vecOrigin; }
 
 	void Teleport(Vector *position, QAngle *angles, Vector *velocity) { CALL_VIRTUAL(void, 148, this, position, angles, velocity); }
 };

--- a/src/cs2_sdk/entity/cbaseplayercontroller.h
+++ b/src/cs2_sdk/entity/cbaseplayercontroller.h
@@ -32,5 +32,5 @@ public:
 	SCHEMA_FIELD(CHandle<CBasePlayerPawn>, m_hPawn)
 	SCHEMA_FIELD(char, m_iszPlayerName)
 
-	CBasePlayerPawn *GetPawn() { return m_hPawn().Get(); }
+	CBasePlayerPawn *GetPawn() { return m_hPawn.Get(); }
 };

--- a/src/cs2_sdk/entity/cbaseplayercontroller.h
+++ b/src/cs2_sdk/entity/cbaseplayercontroller.h
@@ -30,7 +30,9 @@ public:
 
 	SCHEMA_FIELD(uint64, m_steamID)
 	SCHEMA_FIELD(CHandle<CBasePlayerPawn>, m_hPawn)
-	SCHEMA_FIELD(char, m_iszPlayerName)
+	SCHEMA_FIELD_POINTER(char, m_iszPlayerName)
 
 	CBasePlayerPawn *GetPawn() { return m_hPawn.Get(); }
+	const char *GetPlayerName() { return m_iszPlayerName(); }
+	int GetPlayerSlot() { return entindex() - 1; }
 };

--- a/src/cs2_sdk/schema.cpp
+++ b/src/cs2_sdk/schema.cpp
@@ -140,5 +140,5 @@ void SetStateChanged(Z_CBaseEntity* pEntity, int offset)
     if (vars)
 	    pEntity->m_lastNetworkChange = vars->curtime;
 
-	pEntity->m_isSteadyState = 0;
+	pEntity->m_isSteadyState().ClearAll();
 };

--- a/src/cs2_sdk/schema.cpp
+++ b/src/cs2_sdk/schema.cpp
@@ -138,7 +138,7 @@ void SetStateChanged(Z_CBaseEntity* pEntity, int offset)
 	auto vars = GetGameGlobals();
 
     if (vars)
-	    pEntity->m_lastNetworkChange(vars->curtime);
+	    pEntity->m_lastNetworkChange = vars->curtime;
 
-	pEntity->m_isSteadyState(0);
+	pEntity->m_isSteadyState = 0;
 };

--- a/src/cs2_sdk/schema.h
+++ b/src/cs2_sdk/schema.h
@@ -118,69 +118,36 @@ inline constexpr uint64_t hash_64_fnv1a_const(const char *const str, const uint6
 		void operator=(type val) { Set(val); }																				\
 	} varName;
 
-#define SCHEMA_FIELD_OFFSET_OLD(type, varName, extra_offset)                                                      \
-	std::add_lvalue_reference_t<type> varName()                                                                   \
-	{                                                                                                             \
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);                                \
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);                                          \
-                                                                                                                  \
-		static const auto m_key =                                                                                 \
-			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);                                \
-                                                                                                                  \
-		return *reinterpret_cast<std::add_pointer_t<type>>(                                                       \
-			(uintptr_t)(this) + m_key.offset + extra_offset);                                                     \
-	}                                                                                                             \
-	void varName(type val)                                                                                        \
-	{                                                                                                             \
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);                                \
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);                                          \
-                                                                                                                  \
-		static const auto m_key =                                                                                 \
-			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);                                \
-                                                                                                                  \
-		static const auto m_chain =                                                                               \
-			schema::FindChainOffset(ThisClassName);                                                               \
-                                                                                                                  \
-		if (m_chain != 0 && m_key.networked)                                                                      \
-		{                                                                                                         \
-			DevMsg("Found chain offset %d for %s::%s\n", m_chain, ThisClassName, #varName);                       \
-			addresses::NetworkStateChanged((uintptr_t)(this) + m_chain, m_key.offset + extra_offset, 0xFFFFFFFF); \
-		}                                                                                                         \
-		else if (m_key.networked)                                                                                 \
-		{                                                                                                         \
-			/* WIP: Works fine for most props, but inlined classes in the middle of a class will                  \
-				need to have their this pointer corrected by the offset .*/                                       \
-			DevMsg("Attempting to call SetStateChanged on on %s::%s\n", ThisClassName, #varName);                 \
-			if (!IsStruct)                                                                                        \
-				SetStateChanged((Z_CBaseEntity *)this, m_key.offset + extra_offset);                              \
-			else if (IsPlatformPosix()) /* This is currently broken on windows */                                 \
-				CALL_VIRTUAL(void, 1, this, m_key.offset + extra_offset, 0xFFFFFFFF, 0xFFFF);                     \
-		}                                                                                                         \
-		*reinterpret_cast<std::add_pointer_t<type>>((uintptr_t)(this) + m_key.offset + extra_offset) = val;       \
-	}
+#define SCHEMA_FIELD_POINTER_OFFSET(type, varName, extra_offset)															\
+	class varName##_prop																									\
+	{																														\
+	public:																													\
+		type *Get()																											\
+		{																													\
+			static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);										\
+			static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);												\
+																															\
+			static const auto m_key =																						\
+				schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);										\
+																															\
+			static const size_t offset = offsetof(ThisClass, varName);														\
+			ThisClass *pThisClass = (ThisClass *)((byte *)this - offset);													\
+																															\
+			return reinterpret_cast<std::add_pointer_t<type>>(																\
+				(uintptr_t)(pThisClass) + m_key.offset + extra_offset);														\
+		}																													\
+		operator type*() { return Get(); }																					\
+		type* operator ()() { return Get(); }																				\
+		type* operator->() { return Get(); }																				\
+	} varName;
 
+// Use this when you want the member's value itself
 #define SCHEMA_FIELD(type, varName) \
 	SCHEMA_FIELD_OFFSET(type, varName, 0)
 
-#define SCHEMA_FIELD_OLD(type, varName) \
-	SCHEMA_FIELD_OFFSET_OLD(type, varName, 0)
-
-
-#define PSCHEMA_FIELD_OFFSET(type, varName, extra_offset)							\
-	auto varName()																	\
-	{																				\
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);	\
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);			\
-																					\
-		static const auto m_key =													\
-			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);	\
-																					\
-		return reinterpret_cast<std::add_pointer_t<type>>(							\
-			(uintptr_t)(this) + m_key.offset + extra_offset);						\
-	}
-
-#define PSCHEMA_FIELD(type, varName) \
-	PSCHEMA_FIELD_OFFSET(type, varName, 0)
+// Use this when you want a pointer to a member
+#define SCHEMA_FIELD_POINTER(type, varName) \
+	SCHEMA_FIELD_POINTER_OFFSET(type, varName, 0)
 
 namespace schema
 {

--- a/src/cs2_sdk/schema.h
+++ b/src/cs2_sdk/schema.h
@@ -44,7 +44,6 @@ struct SchemaKey {
 	bool networked;
 };
 
-
 class Z_CBaseEntity;
 void SetStateChanged(Z_CBaseEntity* pEntity, int offset);
 
@@ -63,62 +62,120 @@ inline constexpr uint64_t hash_64_fnv1a_const(const char *const str, const uint6
 	return (str[0] == '\0') ? value : hash_64_fnv1a_const(&str[1], (value ^ uint64_t(str[0])) * prime_64_const);
 }
 
-#define SCHEMA_FIELD_OFFSET(type, varName, extra_offset)															\
-	std::add_lvalue_reference_t<type> varName()																		\
-	{																												\
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClass);										\
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);											\
-																													\
-		static const auto m_key =																					\
-			schema::GetOffset(ThisClass, datatable_hash, #varName, prop_hash);										\
-																													\
-		return *reinterpret_cast<std::add_pointer_t<type>>(															\
-			(uintptr_t)(this) + m_key.offset + extra_offset);														\
-	}																												\
-	void varName(type val)																							\
-	{																												\
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClass);										\
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);											\
-																													\
-		static const auto m_key =																					\
-			schema::GetOffset(ThisClass, datatable_hash, #varName, prop_hash);										\
-																													\
-		static const auto m_chain =																					\
-			schema::FindChainOffset(ThisClass);																		\
-																													\
-		if (m_chain != 0 && m_key.networked)																		\
-		{																											\
-			Message("Found chain offset %d for %s::%s\n", m_chain, ThisClass, #varName);							\
-			addresses::NetworkStateChanged((uintptr_t)(this) + m_chain, m_key.offset + extra_offset, 0xFFFFFFFF);	\
-		}																											\
-		else if(m_key.networked)																					\
-		{																											\
-			/* WIP: Works fine for most props, but inlined classes in the middle of a class will
-				need to have their this pointer corrected by the offset .											
-			Message("Attempting to call SetStateChanged on on %s::%s\n", ThisClass, #varName);*/				    \
-			if (!IsStruct)																							\
-				SetStateChanged((Z_CBaseEntity*)this, m_key.offset + extra_offset);									\
-			else if (IsPlatformPosix()) /* This is currently broken on windows */									\
-				CALL_VIRTUAL(void, 1, this, m_key.offset + extra_offset, 0xFFFFFFFF, 0xFFFF);						\
-																													\
-		}																											\
-		*reinterpret_cast<std::add_pointer_t<type>>((uintptr_t)(this) + m_key.offset + extra_offset) = val;			\
+#define SCHEMA_FIELD_OFFSET(type, varName, extra_offset)																	\
+	class varName##_prop																									\
+	{																														\
+	public:																													\
+		std::add_lvalue_reference_t<type> Get()																				\
+		{																													\
+			static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);										\
+			static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);												\
+																															\
+			static const auto m_key =																						\
+				schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);										\
+																															\
+			static const size_t offset = offsetof(ThisClass, varName);														\
+			ThisClass *pThisClass = (ThisClass *)((byte *)this - offset);													\
+																															\
+			return *reinterpret_cast<std::add_pointer_t<type>>(																\
+				(uintptr_t)(pThisClass) + m_key.offset + extra_offset);														\
+		}																													\
+		void Set(type val)																									\
+		{																													\
+			static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);										\
+			static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);												\
+																															\
+			static const auto m_key =																						\
+				schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);										\
+																															\
+			static const auto m_chain =																						\
+				schema::FindChainOffset(ThisClassName);																		\
+																															\
+			static const size_t offset = offsetof(ThisClass, varName);														\
+			ThisClass *pThisClass = (ThisClass *)((byte *)this - offset);													\
+																															\
+			if (m_chain != 0 && m_key.networked)																			\
+			{																												\
+				DevMsg("Found chain offset %d for %s::%s\n", m_chain, ThisClassName, #varName);								\
+				addresses::NetworkStateChanged((uintptr_t)(pThisClass) + m_chain, m_key.offset + extra_offset, 0xFFFFFFFF);	\
+			}																												\
+			else if(m_key.networked)																						\
+			{																												\
+				/* WIP: Works fine for most props, but inlined classes in the middle of a class will
+					need to have their this pointer corrected by the offset .*/												\
+				DevMsg("Attempting to call SetStateChanged on on %s::%s\n", ThisClassName, #varName);						\
+				if (!IsStruct)																								\
+					SetStateChanged((Z_CBaseEntity*)pThisClass, m_key.offset + extra_offset);								\
+				else if (IsPlatformPosix()) /* This is currently broken on windows */										\
+					CALL_VIRTUAL(void, 1, pThisClass, m_key.offset + extra_offset, 0xFFFFFFFF, 0xFFFF);						\
+			}																												\
+			*reinterpret_cast<std::add_pointer_t<type>>((uintptr_t)(pThisClass) + m_key.offset + extra_offset) = val;		\
+		}																													\
+		operator std::add_lvalue_reference_t<type>() { return Get(); }														\
+		std::add_lvalue_reference_t<type> operator ()() { return Get(); }													\
+		std::add_lvalue_reference_t<type> operator->() { return Get(); }													\
+		void operator()(type val) { Set(val); }																				\
+		void operator=(type val) { Set(val); }																				\
+	} varName;
+
+#define SCHEMA_FIELD_OFFSET_OLD(type, varName, extra_offset)                                                      \
+	std::add_lvalue_reference_t<type> varName()                                                                   \
+	{                                                                                                             \
+		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);                                \
+		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);                                          \
+                                                                                                                  \
+		static const auto m_key =                                                                                 \
+			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);                                \
+                                                                                                                  \
+		return *reinterpret_cast<std::add_pointer_t<type>>(                                                       \
+			(uintptr_t)(this) + m_key.offset + extra_offset);                                                     \
+	}                                                                                                             \
+	void varName(type val)                                                                                        \
+	{                                                                                                             \
+		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);                                \
+		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);                                          \
+                                                                                                                  \
+		static const auto m_key =                                                                                 \
+			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);                                \
+                                                                                                                  \
+		static const auto m_chain =                                                                               \
+			schema::FindChainOffset(ThisClassName);                                                               \
+                                                                                                                  \
+		if (m_chain != 0 && m_key.networked)                                                                      \
+		{                                                                                                         \
+			DevMsg("Found chain offset %d for %s::%s\n", m_chain, ThisClassName, #varName);                       \
+			addresses::NetworkStateChanged((uintptr_t)(this) + m_chain, m_key.offset + extra_offset, 0xFFFFFFFF); \
+		}                                                                                                         \
+		else if (m_key.networked)                                                                                 \
+		{                                                                                                         \
+			/* WIP: Works fine for most props, but inlined classes in the middle of a class will                  \
+				need to have their this pointer corrected by the offset .*/                                       \
+			DevMsg("Attempting to call SetStateChanged on on %s::%s\n", ThisClassName, #varName);                 \
+			if (!IsStruct)                                                                                        \
+				SetStateChanged((Z_CBaseEntity *)this, m_key.offset + extra_offset);                              \
+			else if (IsPlatformPosix()) /* This is currently broken on windows */                                 \
+				CALL_VIRTUAL(void, 1, this, m_key.offset + extra_offset, 0xFFFFFFFF, 0xFFFF);                     \
+		}                                                                                                         \
+		*reinterpret_cast<std::add_pointer_t<type>>((uintptr_t)(this) + m_key.offset + extra_offset) = val;       \
 	}
 
 #define SCHEMA_FIELD(type, varName) \
 	SCHEMA_FIELD_OFFSET(type, varName, 0)
 
+#define SCHEMA_FIELD_OLD(type, varName) \
+	SCHEMA_FIELD_OFFSET_OLD(type, varName, 0)
 
-#define PSCHEMA_FIELD_OFFSET(type, varName, extra_offset) \
-	auto varName()																\
-	{																			\
-		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClass);	\
-		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);		\
-																				\
-		static const auto m_key =											\
-			schema::GetOffset(ThisClass, datatable_hash, #varName, prop_hash);	\
-																				\
-		return reinterpret_cast<std::add_pointer_t<type>>(						\
+
+#define PSCHEMA_FIELD_OFFSET(type, varName, extra_offset)							\
+	auto varName()																	\
+	{																				\
+		static constexpr auto datatable_hash = hash_32_fnv1a_const(ThisClassName);	\
+		static constexpr auto prop_hash = hash_32_fnv1a_const(#varName);			\
+																					\
+		static const auto m_key =													\
+			schema::GetOffset(ThisClassName, datatable_hash, #varName, prop_hash);	\
+																					\
+		return reinterpret_cast<std::add_pointer_t<type>>(							\
 			(uintptr_t)(this) + m_key.offset + extra_offset);						\
 	}
 
@@ -131,9 +188,10 @@ namespace schema
 	SchemaKey GetOffset(const char *className, uint32_t classKey, const char *memberName, uint32_t memberKey);
 }
 
-#define DECLARE_SCHEMA_CLASS_BASE(className, isStruct) \
-	static constexpr const char *ThisClass = #className;      \
-	static constexpr bool IsStruct = isStruct;
+#define DECLARE_SCHEMA_CLASS_BASE(className, isStruct)			\
+	typedef className ThisClass;								\
+	static constexpr const char *ThisClassName = #className;	\
+	static constexpr bool IsStruct = isStruct;				  
 
 #define DECLARE_SCHEMA_CLASS(className) DECLARE_SCHEMA_CLASS_BASE(className, false)
 

--- a/src/detours.cpp
+++ b/src/detours.cpp
@@ -169,7 +169,7 @@ void FASTCALL Detour_UTIL_SayText2Filter(
 
 #ifdef _DEBUG
 	if (target)
-		Message("Chat from %s to %s: %s\n", param1, &target->m_iszPlayerName(), param2);
+		Message("Chat from %s to %s: %s\n", param1, target->GetPlayerName(), param2);
 #endif
 
 	UTIL_SayText2Filter(filter, pEntity, eMessageType, msg_name, param1, param2, param3, param4);

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -192,7 +192,7 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 			if (!player)
 				continue;
 
-			if (V_stristr(const_cast<const char*>(&player->m_iszPlayerName()), const_cast<const char*>(target)))
+			if (V_stristr((char*)&player->m_iszPlayerName(), target))
 			{
 				targetType = ETargetType::PLAYER;
 				clients[iNumClients++] = i;

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -192,7 +192,7 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 			if (!player)
 				continue;
 
-			if (V_stristr((char*)&player->m_iszPlayerName(), target))
+			if (V_stristr(player->GetPlayerName(), target))
 			{
 				targetType = ETargetType::PLAYER;
 				clients[iNumClients++] = i;


### PR DESCRIPTION
I rewrote the SCHEMA_FIELD macro to be more flexible. No more `entity->prop(value)` to set the prop value, you can now do `entity->prop = value` like any sane person would. But getting can be more like when directly passing to a va function, in that case you use `entity->prop()` so it explicitly casts to the prop type.