### PR TITLE
Add workaround for crashing server when using buy weapon command

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -76,6 +76,11 @@ WeaponMapEntry_t WeaponMap[] = {
 
 void ParseWeaponCommand(CCSPlayerController *pController, const char *pszWeaponName)
 {
+	if (!pController || !pController->m_hPawn() || pController->m_hPawn()->m_iHealth() <= 0)
+	{
+		ClientPrint(pController, HUD_PRINTTALK, " \7[CS2Fixes]\1 You can only buy weapons when alive.");
+		return;
+	}
 	for (int i = 0; i < sizeof(WeaponMap) / sizeof(*WeaponMap); i++)
 	{
 		WeaponMapEntry_t weaponEntry = WeaponMap[i];


### PR DESCRIPTION
### Bug Description
When dead player or spectator tries to buy weapon it crashes server.

### Expected Behavior
Should ignore the command or send message that tells cannot buy weapon.

### Steps to Reproduce
1. die or go to spectator
2. Use weapon buy command like !he
3. Crashes server

### How to get around it
Add player health check in first line of ParseWeaponCommand() function.