### PR TITLE
Roundstart team switching

### DIFF
--- a/src/addresses.cpp
+++ b/src/addresses.cpp
@@ -49,4 +49,5 @@ void addresses::Initialize()
 	RESOLVE_SIG(modules::server, sigs::UTIL_ClientPrintAll, addresses::UTIL_ClientPrintAll);
 	RESOLVE_SIG(modules::server, sigs::ClientPrint, addresses::ClientPrint);
 	RESOLVE_SIG(modules::server, sigs::SetGroundEntity, addresses::SetGroundEntity);
+	RESOLVE_SIG(modules::server, sigs::CCSPlayerController_SwitchTeam, addresses::CCSPlayerController_SwitchTeam);
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -204,7 +204,7 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
 }
 
-CON_COMMAND_CHAT(stopdecals, "stop world decals")
+CON_COMMAND_CHAT(toggledecals, "toggle world decals, if you're into having 10 fps in ZE")
 {
 	if (!player)
 		return;

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -204,6 +204,27 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
 }
 
+CON_COMMAND_CHAT(stopdecals, "stop world decals")
+{
+	if (!player)
+		return;
+
+	int iPlayer = player->GetPlayerSlot();
+
+	ZEPlayer *pZEPlayer = g_playerManager->GetPlayer(iPlayer);
+
+	// Something has to really go wrong for this to happen
+	if (!pZEPlayer)
+	{
+		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
+		return;
+	}
+
+	pZEPlayer->ToggleStopDecals();
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s world decals", pZEPlayer->IsUsingStopDecals() ? "disabled" : "enabled");
+}
+
 CON_COMMAND_CHAT(ztele, "teleport to spawn")
 {
 	if (!player)

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -201,7 +201,7 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 
 	pZEPlayer->ToggleStopSound();
 
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have % weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
 }
 
 CON_COMMAND_CHAT(ztele, "teleport to spawn")

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -201,7 +201,7 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 
 	pZEPlayer->ToggleStopSound();
 
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX"You have toggled weapon effects.");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have % weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
 }
 
 CON_COMMAND_CHAT(ztele, "teleport to spawn")

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -20,6 +20,8 @@
 #include "protobuf/generated/cstrike15_usermessages.pb.h"
 #include "protobuf/generated/usermessages.pb.h"
 #include "protobuf/generated/cs_gameevents.pb.h"
+#include "protobuf/generated/gameevents.pb.h"
+#include "protobuf/generated/te.pb.h"
 
 #include "cs2fixes.h"
 #include "iserver.h"
@@ -257,7 +259,7 @@ void CS2Fixes::Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClie
 	NetMessageInfo_t* info = pEvent->GetNetMessageInfo();
 
 	//CMsgTEFireBullets
-	if (info->m_MessageId == GE_FireBulletsId)
+	if (info->m_MessageId == GE_FireBulletsId || info->m_MessageId == TE_WorldDecalId)
 	{
 		// Can later do a bit mask for players using stopsound but this will do for now
 		for (uint64 i = 0; i < MAXPLAYERS; i++)
@@ -268,7 +270,11 @@ void CS2Fixes::Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClie
 			if (!(*(uint64 *)clients & ((uint64)1 << i)))
 				continue;
 
-			if (pPlayer && pPlayer->IsUsingStopSound())
+			if (!pPlayer)
+				continue;
+
+			if ((info->m_MessageId == GE_FireBulletsId && pPlayer->IsUsingStopSound()) || 
+				(info->m_MessageId == TE_WorldDecalId && pPlayer->IsUsingStopDecals()))
 			{
 				*(uint64*)clients &= ~((uint64)1 << i);
 				nClientCount--;

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -52,9 +52,11 @@ void UnregisterEventListeners()
 
 bool g_bForceCT = false;
 
-CON_COMMAND_F(c_toggle_team_switching, "toggle forcing CTs on every round", FCVAR_SPONLY | FCVAR_LINKED_CONCOMMAND)
+CON_COMMAND_F(c_force_ct, "toggle forcing CTs on every round", FCVAR_SPONLY | FCVAR_LINKED_CONCOMMAND)
 {
 	g_bForceCT = !g_bForceCT;
+
+	Message("Forcing CTs on every round is now %s.\n", g_bForceCT ? "ON" : "OFF");
 }
 
 GAME_EVENT_F(round_start)

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -59,25 +59,20 @@ CON_COMMAND_F(c_force_ct, "toggle forcing CTs on every round", FCVAR_SPONLY | FC
 	Message("Forcing CTs on every round is now %s.\n", g_bForceCT ? "ON" : "OFF");
 }
 
-GAME_EVENT_F(round_start)
+GAME_EVENT_F(round_prestart)
 {
 	if (!g_bForceCT)
 		return;
 
 	for (int i = 1; i <= MAXPLAYERS; i++)
 	{
-		CBasePlayerController *pController = (CBasePlayerController*)g_pEntitySystem->GetBaseEntity(CEntityIndex(i));
+		CCSPlayerController *pController = (CCSPlayerController *)g_pEntitySystem->GetBaseEntity(CEntityIndex(i));
 
-		if (!pController || pController->m_iTeamNum < CS_TEAM_T)
+		// Only do this for Ts, ignore CTs and specs
+		if (!pController || pController->m_iTeamNum() != CS_TEAM_T)
 			continue;
 
-		CBasePlayerPawn *pPawn = pController->GetPawn();
-
-		if (!pPawn || pPawn->m_iTeamNum < CS_TEAM_T)
-			continue;
-
-		pController->m_iTeamNum = CS_TEAM_CT;
-		pPawn->m_iTeamNum = CS_TEAM_CT;
+		addresses::CCSPlayerController_SwitchTeam(pController, CS_TEAM_CT);
 	}
 }
 

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -42,7 +42,7 @@ public:
 	{ 
 		m_bAuthenticated = false;
 		m_bStopSound = false;
-		m_bStopDecals = false;
+		m_bStopDecals = true;
 		m_iAdminFlags = 0;
 		m_SteamID = nullptr;
 		m_bGagged = false;

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -42,6 +42,7 @@ public:
 	{ 
 		m_bAuthenticated = false;
 		m_bStopSound = false;
+		m_bStopDecals = false;
 		m_iAdminFlags = 0;
 		m_SteamID = nullptr;
 	}
@@ -60,7 +61,9 @@ public:
 	void SetGagged(bool gagged) { m_bGagged = gagged; }
 
 	void ToggleStopSound() { m_bStopSound = !m_bStopSound; }
+	void ToggleStopDecals() { m_bStopDecals = !m_bStopDecals; }
 	bool IsUsingStopSound() { return m_bStopSound; }
+	bool IsUsingStopDecals() { return m_bStopDecals; }
 	bool IsMuted() { return m_bMuted; }
 	bool IsGagged() { return m_bGagged; }
 	CPlayerSlot GetPlayerSlot() { return m_slot; }
@@ -73,6 +76,7 @@ private:
 	bool m_bAuthenticated;
 	const CSteamID* m_SteamID;
 	bool m_bStopSound;
+	bool m_bStopDecals;
 	bool m_bFakeClient;
 	bool m_bMuted;
 	bool m_bGagged;

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -45,6 +45,8 @@ public:
 		m_bStopDecals = false;
 		m_iAdminFlags = 0;
 		m_SteamID = nullptr;
+		m_bGagged = false;
+		m_bMuted = false;
 	}
 
 	bool IsFakeClient() { return m_bFakeClient; }


### PR DESCRIPTION
All terrorists are moved into CT when a round starts, enabled using `c_force_ct` which is a command for now until hl2sdk gets convar support.

Also added `!toggledecals` which toggles emitting world decals (mainly blood), this is disabled by default because blood decals are stupidly expensive in ZE.