### PR TITLE
Fix potential crash when banned players connect

### DIFF
--- a/gamedata/cs2fixes.games.txt
+++ b/gamedata/cs2fixes.games.txt
@@ -199,6 +199,14 @@
                 "windows"       "\x75\x2A\xB3\x01\xEB\x2A\x32\xDB\x45\x32\xED"
                 "linux"         "\x0F\x45\xC1\x4D\x85\xC0\x0F\x95\xC1\x20\xC8"
             }
+
+			// Called right after "Removed %s(%s)\n"
+			"UTIL_Remove"
+            {
+                "library"       "server"
+                "windows"       "\x48\x85\xC9\x74\x2A\x48\x8B\xD1\x48\x8B\x0D\x01\xC1\xDE\x2A"
+                "linux"         "\x48\x89\xFE\x48\x85\xFF\x74\x2A\x48\x8D\x05\x91\xDF\xC4\x2A"
+            }
         }
         "Offsets"
         {

--- a/src/addresses.cpp
+++ b/src/addresses.cpp
@@ -51,4 +51,5 @@ void addresses::Initialize(CGameConfig *g_GameConfig)
 	RESOLVE_SIG(g_GameConfig, "ClientPrint", addresses::ClientPrint);
 	RESOLVE_SIG(g_GameConfig, "SetGroundEntity", addresses::SetGroundEntity);
 	RESOLVE_SIG(g_GameConfig, "CCSPlayerController_SwitchTeam", addresses::CCSPlayerController_SwitchTeam);
+	RESOLVE_SIG(g_GameConfig, "UTIL_Remove", addresses::UTIL_Remove);
 }

--- a/src/addresses.h
+++ b/src/addresses.h
@@ -52,4 +52,5 @@ namespace addresses
 	inline void(FASTCALL *ClientPrint)(CBasePlayerController *player, int msg_dest, const char *msg_name, const char *param1, const char *param2, const char *param3, const char *param4);
 	inline void(FASTCALL *SetGroundEntity)(Z_CBaseEntity *ent, Z_CBaseEntity *ground);
 	inline void(FASTCALL *CCSPlayerController_SwitchTeam)(CCSPlayerController *pController, uint32 team);
+	inline void(FASTCALL *UTIL_Remove)(CEntityInstance*);
 }

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -884,7 +884,7 @@ bool CAdminSystem::LoadInfractions()
 	for (KeyValues* pKey = pKV->GetFirstSubKey(); pKey; pKey = pKey->GetNextKey())
 	{
 		uint64 iSteamId = pKey->GetUint64("steamid", -1);
-		int iEndTime = pKey->GetInt("endtime", -1);
+		time_t iEndTime = pKey->GetUint64("endtime", -1);
 		int iType = pKey->GetInt("type", -1);
 
 		if (iSteamId == -1)
@@ -908,13 +908,13 @@ bool CAdminSystem::LoadInfractions()
 		switch (iType)
 		{
 		case CInfractionBase::Ban:
-			AddInfraction(new CBanInfraction(iEndTime, iSteamId));
+			AddInfraction(new CBanInfraction(iEndTime, iSteamId, true));
 			break;
 		case CInfractionBase::Mute:
-			AddInfraction(new CMuteInfraction(iEndTime, iSteamId));
+			AddInfraction(new CMuteInfraction(iEndTime, iSteamId, true));
 			break;
 		case CInfractionBase::Gag:
-			AddInfraction(new CGagInfraction(iEndTime, iSteamId));
+			AddInfraction(new CGagInfraction(iEndTime, iSteamId, true));
 			break;
 		default:
 			Warning("Invalid infraction type %d\n", iType);
@@ -932,7 +932,7 @@ void CAdminSystem::SaveInfractions()
 
 	FOR_EACH_VEC(m_vecInfractions, i)
 	{
-		int timestamp = m_vecInfractions[i]->GetTimestamp();
+		time_t timestamp = m_vecInfractions[i]->GetTimestamp();
 		if (timestamp != 0 && timestamp < std::time(0))
 			continue;
 
@@ -940,7 +940,7 @@ void CAdminSystem::SaveInfractions()
 		V_snprintf(buf, sizeof(buf), "%d", i);
 		pSubKey = new KeyValues(buf);
 		pSubKey->AddUint64("steamid", m_vecInfractions[i]->GetSteamId64());
-		pSubKey->AddInt("endtime", m_vecInfractions[i]->GetTimestamp());
+		pSubKey->AddUint64("endtime", m_vecInfractions[i]->GetTimestamp());
 		pSubKey->AddInt("type", m_vecInfractions[i]->GetType());
 
 		pKV->AddSubKey(pSubKey);
@@ -977,7 +977,7 @@ bool CAdminSystem::ApplyInfractions(ZEPlayer *player)
 		// Undo the infraction just briefly while checking if it ran out
 		m_vecInfractions[i]->UndoInfraction(player);
 
-		int timestamp = m_vecInfractions[i]->GetTimestamp();
+		time_t timestamp = m_vecInfractions[i]->GetTimestamp();
 		if (timestamp != 0 && timestamp <= std::time(0))
 		{
 			m_vecInfractions.Remove(i);

--- a/src/adminsystem.h
+++ b/src/adminsystem.h
@@ -133,7 +133,7 @@ public:
 	bool LoadInfractions();
 	void AddInfraction(CInfractionBase*);
 	void SaveInfractions();
-	void ApplyInfractions(ZEPlayer *player);
+	bool ApplyInfractions(ZEPlayer *player);
 	bool FindAndRemoveInfraction(ZEPlayer *player, CInfractionBase::EInfractionType type);
 	CAdmin *FindAdmin(uint64 iSteamID);
 

--- a/src/adminsystem.h
+++ b/src/adminsystem.h
@@ -49,10 +49,13 @@
 class CInfractionBase
 {
 public:
-	CInfractionBase(int duration, uint64 steamId) : m_iSteamID(steamId)
+	CInfractionBase(time_t duration, uint64 steamId, bool bEndTime = false) : m_iSteamID(steamId)
 	{
 		// The duration is in minutes here
-		m_iTimestamp = duration != 0 ? std::time(nullptr) + (duration * 60) : 0;
+		if (!bEndTime)
+			m_iTimestamp = duration != 0 ? std::time(nullptr) + (duration * 60) : 0;
+		else
+			m_iTimestamp = duration;
 	}
 	enum EInfractionType
 	{
@@ -64,11 +67,11 @@ public:
 	virtual EInfractionType GetType() = 0;
 	virtual void ApplyInfraction(ZEPlayer*) = 0;
 	virtual void UndoInfraction(ZEPlayer *) = 0;
-	int GetTimestamp() { return m_iTimestamp; }
+	time_t GetTimestamp() { return m_iTimestamp; }
 	uint64 GetSteamId64() { return m_iSteamID; }
 
 private:
-	int m_iTimestamp;
+	time_t m_iTimestamp;
 	uint64 m_iSteamID;
 };
 

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -367,8 +367,9 @@ void CS2Fixes::Hook_OnClientConnected( CPlayerSlot slot, const char *pszName, ui
 bool CS2Fixes::Hook_ClientConnect( CPlayerSlot slot, const char *pszName, uint64 xuid, const char *pszNetworkID, bool unk1, CBufferString *pRejectReason )
 {
 	Message( "Hook_ClientConnect(%d, \"%s\", %lli, \"%s\", %d, \"%s\")\n", slot, pszName, xuid, pszNetworkID, unk1, pRejectReason->ToGrowable()->Get() );
-
-	g_playerManager->OnClientConnected(slot);
+		
+	if (!g_playerManager->OnClientConnected(slot))
+		RETURN_META_VALUE(MRES_SUPERCEDE, false);
 
 	RETURN_META_VALUE(MRES_IGNORED, true);
 }
@@ -376,12 +377,6 @@ bool CS2Fixes::Hook_ClientConnect( CPlayerSlot slot, const char *pszName, uint64
 void CS2Fixes::Hook_ClientPutInServer( CPlayerSlot slot, char const *pszName, int type, uint64 xuid )
 {
 	Message( "Hook_ClientPutInServer(%d, \"%s\", %d, %d, %lli)\n", slot, pszName, type, xuid );
-
-	// Check for infractions in case this player hasn't been authenticated yet
-	ZEPlayer *pPlayer = g_playerManager->GetPlayer(slot);
-	
-	if (pPlayer)
-		pPlayer->CheckInfractions();
 }
 
 void CS2Fixes::Hook_ClientDisconnect( CPlayerSlot slot, int reason, const char *pszName, uint64 xuid, const char *pszNetworkID )

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -376,6 +376,12 @@ bool CS2Fixes::Hook_ClientConnect( CPlayerSlot slot, const char *pszName, uint64
 void CS2Fixes::Hook_ClientPutInServer( CPlayerSlot slot, char const *pszName, int type, uint64 xuid )
 {
 	Message( "Hook_ClientPutInServer(%d, \"%s\", %d, %d, %lli)\n", slot, pszName, type, xuid );
+
+	// Check for infractions in case this player hasn't been authenticated yet
+	ZEPlayer *pPlayer = g_playerManager->GetPlayer(slot);
+	
+	if (pPlayer)
+		pPlayer->CheckInfractions();
 }
 
 void CS2Fixes::Hook_ClientDisconnect( CPlayerSlot slot, int reason, const char *pszName, uint64 xuid, const char *pszNetworkID )

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -49,15 +49,18 @@ public:
 		m_bGagged = false;
 		m_bMuted = false;
 		m_iHideDistance = 0;
+		m_bConnected = false;
 	}
 
 	bool IsFakeClient() { return m_bFakeClient; }
 	bool IsAuthenticated() { return m_bAuthenticated; }
+	bool IsConnected() { return m_bConnected; }
 	uint64 GetSteamId64() { return m_SteamID->ConvertToUint64(); }
 	const CSteamID* GetSteamId() { return m_SteamID; }
 	bool IsAdminFlagSet(uint64 iFlag);
 	
 	void SetAuthenticated() { m_bAuthenticated = true; }
+	void SetConnected() { m_bConnected = true; }
 	void SetSteamId(const CSteamID* steamID) { m_SteamID = steamID; }
 	void SetAdminFlags(uint64 iAdminFlags) { m_iAdminFlags = iAdminFlags; }
 	void SetPlayerSlot(CPlayerSlot slot) { m_slot = slot; }
@@ -83,6 +86,7 @@ public:
 
 private:
 	bool m_bAuthenticated;
+	bool m_bConnected;
 	const CSteamID* m_SteamID;
 	bool m_bStopSound;
 	bool m_bStopDecals;
@@ -104,7 +108,7 @@ public:
 		V_memset(m_UserIdLookup, -1, sizeof(m_UserIdLookup));
 	}
 
-	void OnClientConnected(CPlayerSlot slot);
+	bool OnClientConnected(CPlayerSlot slot);
 	void OnClientDisconnect(CPlayerSlot slot);
 	void OnBotConnected(CPlayerSlot slot);
 	void TryAuthenticate();


### PR DESCRIPTION
Sometimes infractions can be checked (and applied) prior to steam authentication. In such cases, we just directly use the steamid provided when the player connects.

Closes #42 