### PR TITLE
Add silenced weapon sounds to !stopsound

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -187,36 +187,19 @@ void ClientPrint(CBasePlayerController *player, int hud_dest, const char *msg, .
 	addresses::ClientPrint(player, hud_dest, buf, nullptr, nullptr, nullptr, nullptr);
 }
 
-CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
+CON_COMMAND_CHAT(stopsound, "toggle weapon sounds")
 {
 	if (!player)
 		return;
 
 	int iPlayer = player->GetPlayerSlot();
-	bool bSet = !g_playerManager->IsPlayerUsingStopSound(iPlayer);
+	bool bStopSet = g_playerManager->IsPlayerUsingStopSound(iPlayer);
+	bool bSilencedSet = g_playerManager->IsPlayerUsingSilenceSound(iPlayer);
 
-	g_playerManager->SetPlayerStopSound(iPlayer, bSet);
+	g_playerManager->SetPlayerStopSound(iPlayer, bSilencedSet);
+	g_playerManager->SetPlayerSilenceSound(iPlayer, !bSilencedSet && !bStopSet);
 
-	if (bSet)
-		g_playerManager->SetPlayerSilenceSound(iPlayer, false);
-
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects.", bSet ? "disabled" : "enabled");
-}
-
-CON_COMMAND_CHAT(silencesound, "silence weapon sounds")
-{
-	if (!player)
-		return;
-
-	int iPlayer = player->GetPlayerSlot();
-	bool bSet = !g_playerManager->IsPlayerUsingSilenceSound(iPlayer);
-
-	g_playerManager->SetPlayerSilenceSound(iPlayer, bSet);
-
-	if (bSet)
-		g_playerManager->SetPlayerStopSound(iPlayer, false);
-
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon sounds.", bSet ? "silenced" : "unsilenced");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon sounds.", bSilencedSet ? "disabled" : !bSilencedSet && !bStopSet ? "silenced" : "enabled");
 }
 
 CON_COMMAND_CHAT(toggledecals, "toggle world decals, if you're into having 10 fps in ZE")

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -193,19 +193,30 @@ CON_COMMAND_CHAT(stopsound, "stop weapon sounds")
 		return;
 
 	int iPlayer = player->GetPlayerSlot();
+	bool bSet = !g_playerManager->IsPlayerUsingStopSound(iPlayer);
 
-	ZEPlayer *pZEPlayer = g_playerManager->GetPlayer(iPlayer);
+	g_playerManager->SetPlayerStopSound(iPlayer, bSet);
 
-	// Something has to really go wrong for this to happen
-	if (!pZEPlayer)
-	{
-		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
+	if (bSet)
+		g_playerManager->SetPlayerSilenceSound(iPlayer, false);
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects.", bSet ? "disabled" : "enabled");
+}
+
+CON_COMMAND_CHAT(silencesound, "silence weapon sounds")
+{
+	if (!player)
 		return;
-	}
 
-	pZEPlayer->ToggleStopSound();
+	int iPlayer = player->GetPlayerSlot();
+	bool bSet = !g_playerManager->IsPlayerUsingSilenceSound(iPlayer);
 
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon effects", pZEPlayer->IsUsingStopSound() ? "disabled" : "enabled");
+	g_playerManager->SetPlayerSilenceSound(iPlayer, bSet);
+
+	if (bSet)
+		g_playerManager->SetPlayerStopSound(iPlayer, false);
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s weapon sounds.", bSet ? "silenced" : "unsilenced");
 }
 
 CON_COMMAND_CHAT(toggledecals, "toggle world decals, if you're into having 10 fps in ZE")
@@ -214,19 +225,11 @@ CON_COMMAND_CHAT(toggledecals, "toggle world decals, if you're into having 10 fp
 		return;
 
 	int iPlayer = player->GetPlayerSlot();
+	bool bSet = !g_playerManager->IsPlayerUsingStopDecals(iPlayer);
 
-	ZEPlayer *pZEPlayer = g_playerManager->GetPlayer(iPlayer);
+	g_playerManager->SetPlayerStopDecals(iPlayer, bSet);
 
-	// Something has to really go wrong for this to happen
-	if (!pZEPlayer)
-	{
-		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
-		return;
-	}
-
-	pZEPlayer->ToggleStopDecals();
-
-	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s world decals", pZEPlayer->IsUsingStopDecals() ? "disabled" : "enabled");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s world decals.", bSet ? "disabled" : "enabled");
 }
 
 CON_COMMAND_CHAT(myuid, "test")

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -322,7 +322,7 @@ void CS2Fixes::Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClie
 			// original weapon_id will override new settings if not removed
 			msg->set_weapon_id(0);
 			msg->set_sound_type(10);
-			msg->set_item_def_index(60); // weapon_m4a1_silencer
+			msg->set_item_def_index(61); // weapon_usp_silencer
 
 			uint64 clientMask = *(uint64 *)clients & g_playerManager->GetSilenceSoundMask();
 

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -303,7 +303,18 @@ void CS2Fixes::Hook_PostEvent(CSplitScreenSlot nSlot, bool bLocalOnly, int nClie
 
 	NetMessageInfo_t* info = pEvent->GetNetMessageInfo();
 
-	//CMsgTEFireBullets
+	// Default silenced weapon sounds
+	// Ideally this would be toggleable betwen default/silenced, but does not seem possible to send new protobuf msgs currently
+	if (info->m_MessageId == GE_FireBulletsId)
+	{
+		CMsgTEFireBullets* msg = (CMsgTEFireBullets*)pData;
+
+		// original weapon_id will override new settings if not removed
+		msg->set_weapon_id(0);
+		msg->set_sound_type(10);
+		msg->set_item_def_index(60); // weapon_m4a1_silencer
+	}
+
 	if (info->m_MessageId == GE_FireBulletsId || info->m_MessageId == TE_WorldDecalId)
 	{
 		// Can later do a bit mask for players using stopsound but this will do for now

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -85,6 +85,8 @@ bool CPlayerManager::OnClientConnected(CPlayerSlot slot)
 	pPlayer->SetConnected();
 	m_vecPlayers[slot.Get()] = pPlayer;
 	m_UserIdLookup[g_pEngineServer2->GetPlayerUserId(slot).Get()] = slot.Get();
+
+	ResetPlayerFlags(slot.Get());
 	
 	return true;
 }
@@ -96,6 +98,8 @@ void CPlayerManager::OnClientDisconnect(CPlayerSlot slot)
 	delete m_vecPlayers[slot.Get()];
 	m_vecPlayers[slot.Get()] = nullptr;
 	m_UserIdLookup[g_pEngineServer2->GetPlayerUserId(slot).Get()] = -1;
+
+	ResetPlayerFlags(slot.Get());
 }
 
 void CPlayerManager::TryAuthenticate()
@@ -302,4 +306,35 @@ ZEPlayer *CPlayerManager::GetPlayerFromUserId(int userid)
 		return nullptr;
 
 	return m_vecPlayers[m_UserIdLookup[userid]];
+}
+
+void CPlayerManager::SetPlayerStopSound(int slot, bool set)
+{
+	if (set)
+		m_nUsingStopSound |= ((uint64)1 << slot);
+	else
+		m_nUsingStopSound &= ~((uint64)1 << slot);
+}
+
+void CPlayerManager::SetPlayerSilenceSound(int slot, bool set)
+{
+	if (set)
+		m_nUsingSilenceSound |= ((uint64)1 << slot);
+	else
+		m_nUsingSilenceSound &= ~((uint64)1 << slot);
+}
+
+void CPlayerManager::SetPlayerStopDecals(int slot, bool set)
+{
+	if (set)
+		m_nUsingStopDecals |= ((uint64)1 << slot);
+	else
+		m_nUsingStopDecals &= ~((uint64)1 << slot);
+}
+
+void CPlayerManager::ResetPlayerFlags(int slot)
+{
+	SetPlayerStopSound(slot, false);
+	SetPlayerSilenceSound(slot, false);
+	SetPlayerStopDecals(slot, true);
 }

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -335,6 +335,6 @@ void CPlayerManager::SetPlayerStopDecals(int slot, bool set)
 void CPlayerManager::ResetPlayerFlags(int slot)
 {
 	SetPlayerStopSound(slot, false);
-	SetPlayerSilenceSound(slot, false);
+	SetPlayerSilenceSound(slot, true);
 	SetPlayerStopDecals(slot, true);
 }

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -103,7 +103,7 @@ public:
 		V_memset(m_vecPlayers, 0, sizeof(m_vecPlayers));
 		V_memset(m_UserIdLookup, -1, sizeof(m_UserIdLookup));
 		m_nUsingStopSound = 0;
-		m_nUsingSilenceSound = 0;
+		m_nUsingSilenceSound = -1; // On by default
 		m_nUsingStopDecals = -1; // On by default
 	}
 

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -42,8 +42,6 @@ public:
 	ZEPlayer(CPlayerSlot slot, bool m_bFakeClient = false): m_slot(slot), m_bFakeClient(m_bFakeClient)
 	{ 
 		m_bAuthenticated = false;
-		m_bStopSound = false;
-		m_bStopDecals = true;
 		m_iAdminFlags = 0;
 		m_SteamID = nullptr;
 		m_bGagged = false;
@@ -70,12 +68,8 @@ public:
 	void SetTransmit(int index, bool shouldTransmit) { shouldTransmit ? m_shouldTransmit.Set(index) : m_shouldTransmit.Clear(index); }
 	void ClearTransmit() { m_shouldTransmit.ClearAll(); }
 	void SetHideDistance(int distance) { m_iHideDistance = distance; }
-	void ToggleStopSound() { m_bStopSound = !m_bStopSound; }
-	void ToggleStopDecals() { m_bStopDecals = !m_bStopDecals; }
 	void SetTotalDamage(int damage) { m_iTotalDamage = damage; }
 
-	bool IsUsingStopSound() { return m_bStopSound; }
-	bool IsUsingStopDecals() { return m_bStopDecals; }
 	bool IsMuted() { return m_bMuted; }
 	bool IsGagged() { return m_bGagged; }
 	bool ShouldBlockTransmit(int index) { return m_shouldTransmit.Get(index); }
@@ -91,8 +85,6 @@ private:
 	bool m_bAuthenticated;
 	bool m_bConnected;
 	const CSteamID* m_SteamID;
-	bool m_bStopSound;
-	bool m_bStopDecals;
 	bool m_bFakeClient;
 	bool m_bMuted;
 	bool m_bGagged;
@@ -110,6 +102,9 @@ public:
 	{
 		V_memset(m_vecPlayers, 0, sizeof(m_vecPlayers));
 		V_memset(m_UserIdLookup, -1, sizeof(m_UserIdLookup));
+		m_nUsingStopSound = 0;
+		m_nUsingSilenceSound = 0;
+		m_nUsingStopDecals = -1; // On by default
 	}
 
 	bool OnClientConnected(CPlayerSlot slot);
@@ -123,9 +118,27 @@ public:
 	ETargetType TargetPlayerString(int iCommandClient, const char* target, int &iNumClients, int *clients);
 	ZEPlayer *GetPlayer(CPlayerSlot slot) { return m_vecPlayers[slot.Get()]; };
 
+	uint64 GetStopSoundMask() { return m_nUsingStopSound; }
+	uint64 GetSilenceSoundMask() { return m_nUsingSilenceSound; }
+	uint64 GetStopDecalsMask() { return m_nUsingStopDecals; }
+	
+	void SetPlayerStopSound(int slot, bool set);
+	void SetPlayerSilenceSound(int slot, bool set);
+	void SetPlayerStopDecals(int slot, bool set);
+
+	void ResetPlayerFlags(int slot);
+
+	bool IsPlayerUsingStopSound(int slot) { return m_nUsingStopSound & ((uint64)1 << slot); }
+	bool IsPlayerUsingSilenceSound(int slot) { return m_nUsingSilenceSound & ((uint64)1 << slot); }
+	bool IsPlayerUsingStopDecals(int slot) { return m_nUsingStopDecals & ((uint64)1 << slot); }
+
 private:
 	ZEPlayer* m_vecPlayers[MAXPLAYERS];
 	uint16 m_UserIdLookup[USHRT_MAX+1];
+
+	uint64 m_nUsingStopSound;
+	uint64 m_nUsingSilenceSound;
+	uint64 m_nUsingStopDecals;
 };
 
 extern CPlayerManager *g_playerManager;


### PR DESCRIPTION
Adds an extra mode to !stopsound which replaces all gun sounds heard by a client with a silenced one, except their own.