### PR TITLE
Add !rcon/c_rcon

### DIFF
--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -823,6 +823,30 @@ CON_COMMAND_CHAT(hsay, "say something as a hud hint")
 	ClientPrintAll(HUD_PRINTCENTER, "%s", args.ArgS());
 }
 
+CON_COMMAND_CHAT(rcon, "send a command to server console")
+{
+	if (!player)
+		return;
+
+	int iCommandPlayer = player->GetPlayerSlot();
+
+	ZEPlayer* pPlayer = g_playerManager->GetPlayer(iCommandPlayer);
+
+	if (!pPlayer->IsAdminFlagSet(ADMFLAG_RCON))
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You don't have access to this command.");
+		return;
+	}
+
+	if (args.ArgC() < 2)
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !rcon <command>");
+		return;
+	}
+
+	g_pEngineServer2->ServerCommand(args.ArgS());
+}
+
 bool CAdminSystem::LoadAdmins()
 {
 	m_vecAdmins.Purge();


### PR DESCRIPTION
Equivalent to SourceMod's `sm_rcon`, ingame access to server console that isn't really "rcon", requires the rcon admin flag to use.

(i was getting tired of constantly tabbing out of game into server console)