### PR TITLE
Add base foundation for HTTP, basic GET/POST API, debug command

### DIFF
--- a/AMBuildScript
+++ b/AMBuildScript
@@ -274,7 +274,7 @@ class MMSPluginConfig(object):
 
     elif cxx.like('msvc'):
       if builder.options.debug == '1':
-        cxx.cflags += ['/MTd']
+        cxx.cflags += ['/MDd']
         cxx.linkflags += ['/NODEFAULTLIB:libcmt']
       else:
         cxx.cflags += ['/MT']

--- a/AMBuilder
+++ b/AMBuilder
@@ -50,7 +50,7 @@ for sdk_name in MMSPlugin.sdks:
       'src/mempatch.cpp',
       'src/patches.cpp',
       'src/cvars.cpp',
-	  'src/adminsystem.cpp',
+      'src/adminsystem.cpp',
       'src/commands.cpp',
       'src/addresses.cpp',
       'src/detours.cpp',
@@ -61,6 +61,7 @@ for sdk_name in MMSPlugin.sdks:
       'src/ctimer.cpp',
       'src/playermanager.cpp',
       'src/gameconfig.cpp',
+      'src/httpmanager.cpp',
     ]
 
     if sdk_name in ['dota', 'cs2']:

--- a/AMBuilder
+++ b/AMBuilder
@@ -41,6 +41,7 @@ for sdk_name in MMSPlugin.sdks:
         os.path.join(builder.sourcePath, 'vendor', 'funchook', 'lib', 'funchook.lib'),
         os.path.join(builder.sourcePath, 'vendor', 'funchook', 'lib', 'distorm.lib'),
         os.path.join(builder.sourcePath, 'vendor', 'protobuf-lib', 'libprotobuf.lib'),
+		os.path.join(builder.sourcePath, 'sdk', 'lib', 'public', 'win64', 'steam_api64.lib')
       ]
       binary.sources += ['src/utils/plat_win.cpp']
 
@@ -67,8 +68,12 @@ for sdk_name in MMSPlugin.sdks:
     if sdk_name in ['dota', 'cs2']:
       binary.sources += [
       os.path.join(sdk.path, 'entity2', 'entitysystem.cpp'),
-      os.path.join(sdk.path, 'tier1', 'convar.cpp'),
-      os.path.join(sdk.path, 'public', 'tier0', 'memoverride.cpp'),
+      os.path.join(sdk.path, 'tier1', 'convar.cpp')
+    ]
+
+    if sdk_name in ['dota', 'cs2'] and (binary.compiler.target.platform == 'windows' and builder.options.debug != '1') or binary.compiler.target.platform == 'linux':
+      binary.sources += [
+      os.path.join(sdk.path, 'public', 'tier0', 'memoverride.cpp')
     ]
 
     if cxx.target.arch == 'x86':

--- a/CS2Fixes.vcxproj
+++ b/CS2Fixes.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -177,6 +177,7 @@
     <ClCompile Include="src\detours.cpp" />
     <ClCompile Include="src\events.cpp" />
     <ClCompile Include="src\gameconfig.cpp" />
+    <ClCompile Include="src\httpmanager.cpp" />
     <ClCompile Include="src\mempatch.cpp" />
     <ClCompile Include="src\patches.cpp" />
     <ClCompile Include="src\playermanager.cpp" />
@@ -209,6 +210,7 @@
     <ClInclude Include="src\ctimer.h" />
     <ClInclude Include="src\detours.h" />
     <ClInclude Include="src\eventlistener.h" />
+    <ClInclude Include="src\httpmanager.h" />
     <ClInclude Include="src\mempatch.h" />
     <ClInclude Include="src\addresses.h" />
     <ClInclude Include="src\playermanager.h" />

--- a/CS2Fixes.vcxproj
+++ b/CS2Fixes.vcxproj
@@ -131,7 +131,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>interfaces.lib;tier0.lib;tier1.lib;psapi.lib;funchook.lib;distorm.lib;vendor/protobuf-lib/libprotobuf.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>interfaces.lib;tier0.lib;tier1.lib;psapi.lib;funchook.lib;distorm.lib;steam_api64.lib;vendor/protobuf-lib/libprotobuf.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>sdk/lib/public/win64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ShowProgress>
       </ShowProgress>
@@ -149,7 +149,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>src/utils;src/cs2_sdk;sdk/public;sdk/public/tier0;sdk/game/shared;sdk/game/server;sdk/public/tier1;minhook/include;$(MMSOURCE112)/core;$(MMSOURCE112)/core/sourcehook;vendor/subhook;vendor/funchook/include;sdk/public/entity2;sdk/public/game/server;vendor/protobuf-3.21.8/src;$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
       <UndefinePreprocessorDefinitions>%(UndefinePreprocessorDefinitions)</UndefinePreprocessorDefinitions>
     </ClCompile>
     <Link>
@@ -158,7 +158,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>interfaces.lib;tier0.lib;tier1.lib;psapi.lib;funchook.lib;distorm.lib;vendor/protobuf-lib/libprotobuf.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>interfaces.lib;tier0.lib;tier1.lib;psapi.lib;funchook.lib;distorm.lib;steam_api64.lib;vendor/protobuf-lib/libprotobuf.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>sdk/lib/public/win64;vendor/funchook/lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <ShowProgress>
       </ShowProgress>

--- a/CS2Fixes.vcxproj.filters
+++ b/CS2Fixes.vcxproj.filters
@@ -95,6 +95,9 @@
     <ClCompile Include="sdk\tier1\convar.cpp">
       <Filter>Source Files\sdk</Filter>
     </ClCompile>
+    <ClCompile Include="src\httpmanager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\mempatch.h">
@@ -188,6 +191,9 @@
       <Filter>Header Files\cs2_sdk\entity</Filter>
     </ClInclude>
     <ClInclude Include="src\eventlistener.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\httpmanager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -584,7 +584,7 @@ CON_COMMAND_CHAT(http, "test an HTTP request")
 
 		return;
 	}
-	if (args.ArgC() < 4)
+	if (args.ArgC() < 3)
 	{
 		if (player)
 			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !http <get/post> <url> [content]");

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -31,11 +31,13 @@
 #include "playermanager.h"
 #include "adminsystem.h"
 #include "ctimer.h"
+#include "httpmanager.h"
 
 #include "tier0/memdbgon.h"
 
 extern CEntitySystem *g_pEntitySystem;
 extern IVEngineServer2* g_pEngineServer2;
+extern ISteamHTTP* g_http;
 
 WeaponMapEntry_t WeaponMap[] = {
 	{"bizon",		  "weapon_bizon",			 1400, 26},
@@ -564,6 +566,38 @@ CON_COMMAND_CHAT(setinteraction, "set a player's interaction flags")
 
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Setting interaction flags on %s from %llx to %llx.", pTarget->GetPlayerName(), oldInteractAs, newInteract);
 	}
+}
+
+void HttpCallback(HTTPRequestHandle request, char* response)
+{
+	ClientPrintAll(HUD_PRINTTALK, response);
+}
+
+CON_COMMAND_CHAT(http, "test an HTTP request")
+{
+	if (!g_http)
+	{
+		if (player)
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Steam HTTP interface is not available!");
+		else
+			Message(CHAT_PREFIX "Steam HTTP interface is not available!\n");
+
+		return;
+	}
+	if (args.ArgC() < 4)
+	{
+		if (player)
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !http <get/post> <url> [content]");
+		else
+			Message(CHAT_PREFIX "Usage: !http <get/post> <url> [content]\n");
+
+		return;
+	}
+
+	if (strcmp(args[1], "get") == 0)
+		g_HTTPManager.GET(args[2], &HttpCallback);
+	else if (strcmp(args[1], "post") == 0)
+		g_HTTPManager.POST(args[2], args[3], &HttpCallback);
 }
 #endif // _DEBUG
 

--- a/src/cs2fixes.h
+++ b/src/cs2fixes.h
@@ -38,6 +38,8 @@ public:
 	bool Unpause(char *error, size_t maxlen);
 	void AllPluginsLoaded();
 public: //hooks
+	void Hook_GameServerSteamAPIActivated();
+	void Hook_GameServerSteamAPIDeactivated();
 	void OnLevelInit( char const *pMapName,
 				 char const *pMapEntities,
 				 char const *pOldLevel,

--- a/src/httpmanager.cpp
+++ b/src/httpmanager.cpp
@@ -1,0 +1,120 @@
+/**
+ * =============================================================================
+ * CS2Fixes
+ * Copyright (C) 2023 Source2ZE
+ * Original code from D2Lobby2
+ * Copyright (C) 2023 Nicholas Hastings
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0 or later, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, you are also granted permission to link the code
+ * of this program (as well as its derivative works) to "Dota 2," the
+ * "Source Engine, and any Game MODs that run on software by the Valve Corporation.
+ * You must obey the GNU General Public License in all respects for all other
+ * code used.  Additionally, this exception is granted to all derivative works.
+ */
+
+#include "httpmanager.h"
+#include "common.h"
+#include <string>
+
+extern ISteamHTTP* g_http;
+
+HTTPManager g_HTTPManager;
+
+#undef strdup
+
+HTTPManager::TrackedRequest::TrackedRequest(HTTPRequestHandle hndl, SteamAPICall_t hCall, const char* pszUrl, const char* pszText, CompletedCallback callback)
+{
+	m_hHTTPReq = hndl;
+	m_CallResult.SetGameserverFlag();
+	m_CallResult.Set(hCall, this, &TrackedRequest::OnHTTPRequestCompleted);
+
+	m_pszUrl = strdup(pszUrl);
+	m_pszText = strdup(pszText);
+	m_callback = callback;
+
+	g_HTTPManager.m_PendingRequests.push_back(this);
+}
+
+HTTPManager::TrackedRequest::~TrackedRequest()
+{
+	for (auto e = g_HTTPManager.m_PendingRequests.begin(); e != g_HTTPManager.m_PendingRequests.end(); ++e)
+	{
+		if (*e == this)
+		{
+			g_HTTPManager.m_PendingRequests.erase(e);
+			break;
+		}
+	}
+
+	free(m_pszUrl);
+	free(m_pszText);
+}
+
+void HTTPManager::TrackedRequest::OnHTTPRequestCompleted(HTTPRequestCompleted_t* arg, bool bFailed)
+{
+	if (bFailed || arg->m_eStatusCode < 200 || arg->m_eStatusCode > 299)
+	{
+		Message("HTTP request to %s failed with status code %i\n", m_pszUrl, arg->m_eStatusCode);
+	}
+	else
+	{
+		uint32 size;
+		g_http->GetHTTPResponseBodySize(arg->m_hRequest, &size);
+
+		uint8* response = new uint8[size];
+		g_http->GetHTTPResponseBodyData(arg->m_hRequest, response, size);
+
+		// Pass on response to the custom callback
+		m_callback(arg->m_hRequest, (char*)response);
+	}
+
+	if (g_http)
+		g_http->ReleaseHTTPRequest(arg->m_hRequest);
+
+	delete this;
+}
+
+void HTTPManager::GET(const char* pszUrl, CompletedCallback callback)
+{
+	GenerateRequest(k_EHTTPMethodGET, pszUrl, "", callback);
+}
+
+void HTTPManager::POST(const char* pszUrl, const char* pszText, CompletedCallback callback)
+{
+	GenerateRequest(k_EHTTPMethodPOST, pszUrl, pszText, callback);
+}
+
+void HTTPManager::GenerateRequest(EHTTPMethod method, const char* pszUrl, const char* pszText, CompletedCallback callback)
+{
+	//Message("Sending HTTP:\n%s\n", pszText);
+	auto hReq = g_http->CreateHTTPRequest(method, pszUrl);
+	int size = strlen(pszText);
+	//Message("HTTP request: %p\n", hReq);
+
+	if (method == k_EHTTPMethodPOST && !g_http->SetHTTPRequestRawPostBody(hReq, "application/json", (uint8*)pszText, size))
+	{
+		//Message("Failed to SetHTTPRequestRawPostBody\n");
+		return;
+	}
+
+	// Prevent HTTP error 411 (probably not necessary?)
+	//g_http->SetHTTPRequestHeaderValue(hReq, "Content-Length", std::to_string(size).c_str());
+
+	SteamAPICall_t hCall;
+	g_http->SendHTTPRequest(hReq, &hCall);
+
+	new TrackedRequest(hReq, hCall, pszUrl, pszText, callback);
+}

--- a/src/httpmanager.h
+++ b/src/httpmanager.h
@@ -1,0 +1,67 @@
+/**
+ * =============================================================================
+ * CS2Fixes
+ * Copyright (C) 2023 Source2ZE
+ * Original code from D2Lobby2
+ * Copyright (C) 2023 Nicholas Hastings
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 2.0 or later, as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * As a special exception, you are also granted permission to link the code
+ * of this program (as well as its derivative works) to "Dota 2," the
+ * "Source Engine, and any Game MODs that run on software by the Valve Corporation.
+ * You must obey the GNU General Public License in all respects for all other
+ * code used.  Additionally, this exception is granted to all derivative works.
+ */
+
+#pragma once
+
+#include "cs2fixes.h"
+#include <steam/steam_gameserver.h>
+
+#include <vector>
+#include <functional>
+
+class HTTPManager;
+extern HTTPManager g_HTTPManager;
+
+#define CompletedCallback std::function<void(HTTPRequestHandle, char*)>
+
+class HTTPManager
+{
+public:
+	void GET(const char* pszUrl, CompletedCallback callback);
+	void POST(const char* pszUrl, const char* pszText, CompletedCallback callback);
+	bool HasAnyPendingRequests() const { return m_PendingRequests.size() > 0; }
+
+private:
+	class TrackedRequest
+	{
+	public:
+		TrackedRequest(const TrackedRequest& req) = delete;
+		TrackedRequest(HTTPRequestHandle hndl, SteamAPICall_t hCall, const char* pszUrl, const char* pszText, CompletedCallback callback);
+		~TrackedRequest();
+	private:
+		void OnHTTPRequestCompleted(HTTPRequestCompleted_t* arg, bool bFailed);
+
+		HTTPRequestHandle m_hHTTPReq;
+		CCallResult<TrackedRequest, HTTPRequestCompleted_t> m_CallResult;
+		char* m_pszUrl;
+		char* m_pszText;
+		CompletedCallback m_callback;
+	};
+private:
+	std::vector<HTTPManager::TrackedRequest*> m_PendingRequests;
+	void GenerateRequest(EHTTPMethod method, const char* pszUrl, const char* pszText, CompletedCallback callback);
+};


### PR DESCRIPTION
Using ISteamHTTP, so no third party dependencies introduced (yet, we probably want a proper JSON implementation later). 

[D2Lobby2](https://github.com/psychonic/d2lobby2/blob/master/httpmgr.cpp) was used as a starting point after seeing it shared in AM discord, so I've maintained the license headers (we're also GPL anyways).

The `c_http` command is available in debug builds for testing, some examples:
```
c_http post "https://httpbin.org/post" "{test: true}"
c_http get "https://httpbin.org/get"
c_http get "https://vauff.com/mapimgs/list.php"
```