### PR TITLE
Add default argument for !hide

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -323,6 +323,7 @@ CON_COMMAND_CHAT(ztele, "teleport to spawn")
 }
 
 // CONVAR_TODO
+static constexpr int g_iDefaultHideDistance = 250;
 static constexpr int g_iMaxHideDistance = 2000;
 
 CON_COMMAND_CHAT(hide, "hides nearby teammates")
@@ -333,13 +334,12 @@ CON_COMMAND_CHAT(hide, "hides nearby teammates")
 		return;
 	}
 
-	if (args.ArgC() < 2)
-	{
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !hide <distance> (0 to disable)");
-		return;
-	}
+	int distance;
 
-	int distance = V_StringToInt32(args[1], -1);
+	if (args.ArgC() < 2)
+		distance = g_iDefaultHideDistance;
+	else
+		distance = V_StringToInt32(args[1], -1);
 
 	if (distance > g_iMaxHideDistance || distance < 0)
 	{
@@ -358,7 +358,7 @@ CON_COMMAND_CHAT(hide, "hides nearby teammates")
 		return;
 	}
 
-	// allows for toggling hide with a bind by turning off when hide distance matches.
+	// allows for toggling hide by turning off when hide distance matches.
 	if (pZEPlayer->GetHideDistance() == distance)
 		distance = 0;
 


### PR DESCRIPTION
Allows for a simple toggle with just `!hide`, without newer players having to mess around with distances.