### PR TITLE
Feat: Add convar option for toggling ztele command for humans

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -263,9 +263,9 @@ CON_COMMAND_CHAT(ztele, "teleport to spawn")
 	}
 
 	// Check if command is enabled for humans
-	if (!g_bZteleHuman)
+	if (!g_bZteleHuman && player->m_iTeamNum() == CS_TEAM_CT)
 	{
-		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command as a human.");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You cannot use this command as a human.");
 		return;
 	}
 

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -252,12 +252,20 @@ CON_COMMAND_CHAT(myuid, "test")
 
 // CONVAR_TODO
 static constexpr float g_flMaxZteleDistance = 150.0f;
+static constexpr bool g_bZteleHuman = false;
 
 CON_COMMAND_CHAT(ztele, "teleport to spawn")
 {
 	if (!player)
 	{
 		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command from the server console.");
+		return;
+	}
+
+	// Check if command is enabled for humans
+	if (!g_bZteleHuman)
+	{
+		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command as a human.");
 		return;
 	}
 


### PR DESCRIPTION
CS2Fixes, in its current state, allows for all players to use !ztele command. This PR adds a bool in the command to change whether if humans can use the command.

**UNTESTED**