### PR TITLE
Add personal damage feedback if not in the top 5 defenders

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -199,12 +199,16 @@ GAME_EVENT_F(round_end)
 
 	char colorMap[] = { '\x10', '\x08', '\x09', '\x0B'};
 
-	for (int i = 0; i < MIN(sortedPlayers.Count(), 5); i++)
+	for (int i = 0; i < sortedPlayers.Count(); i++)
 	{
 		ZEPlayer* pPlayer = sortedPlayers[i];
 		CCSPlayerController* pController = CCSPlayerController::FromSlot(pPlayer->GetPlayerSlot());
 
-		ClientPrintAll(HUD_PRINTTALK, " %c%i. %s \x01- \x07%i DMG", colorMap[MIN(i, 3)], i + 1, pController->GetPlayerName(), pPlayer->GetTotalDamage());
+		if (i < 5)
+			ClientPrintAll(HUD_PRINTTALK, " %c%i. %s \x01- \x07%i DMG", colorMap[MIN(i, 3)], i + 1, pController->GetPlayerName(), pPlayer->GetTotalDamage());
+		else
+			ClientPrint(pController, HUD_PRINTTALK, " \x0C%i. %s \x01- \x07%i DMG", i + 1, pController->GetPlayerName(), pPlayer->GetTotalDamage());
+		
 		pPlayer->SetTotalDamage(0);
 	}
 }


### PR DESCRIPTION
In the absence of !tdrank or similar, there is no way to know your own personal damage at the end of a round unless you were in the top 5.

This change will display the player's personal rank at the end of a round, in the next line after the 5th top defender position. The message will only be visible to the specific player in question, and only appear if they are below rank 5. It uses a darker blue colour for now.