### PR TITLE
Fix several Steam ID/authentication issues

### DIFF
--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -70,7 +70,7 @@ CON_COMMAND_F(c_reload_admins, "Reload admin config", FCVAR_SPONLY | FCVAR_LINKE
 	{
 		ZEPlayer* pPlayer = g_playerManager->GetPlayer(i);
 
-		if (!pPlayer || pPlayer->IsFakeClient())
+		if (!pPlayer || pPlayer->IsFakeClient() || !pPlayer->IsAuthenticated())
 			continue;
 
 		pPlayer->CheckAdmin();

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -138,6 +138,12 @@ CON_COMMAND_CHAT_FLAGS(ban, "ban a player", ADMFLAG_BAN)
 	if (pTargetPlayer->IsFakeClient())
 		return;
 
+	if (!pTargetPlayer->IsAuthenticated())
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is not yet authenticated, consider kicking instead or please wait a moment and try again.", pTarget->GetPlayerName());
+		return;
+	}
+
 	CInfractionBase *infraction = new CBanInfraction(iDuration, pTargetPlayer->GetSteamId64());
 
 	g_pAdminSystem->AddInfraction(infraction);
@@ -210,6 +216,12 @@ CON_COMMAND_CHAT_FLAGS(mute, "mutes a player", ADMFLAG_CHAT)
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
+
+		if (!pTargetPlayer->IsAuthenticated())
+		{
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is not yet authenticated, please wait a moment and try again.", pTarget->GetPlayerName());
+			continue;
+		}
 
 		CInfractionBase* infraction = new CMuteInfraction(iDuration, pTargetPlayer->GetSteamId64());
 
@@ -329,6 +341,12 @@ CON_COMMAND_CHAT_FLAGS(gag, "gag a player", ADMFLAG_CHAT)
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
+
+		if (!pTargetPlayer->IsAuthenticated())
+		{
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is not yet authenticated, please wait a moment and try again.", pTarget->GetPlayerName());
+			continue;
+		}
 
 		CInfractionBase *infraction = new CGagInfraction(iDuration, pTargetPlayer->GetSteamId64());
 

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -1095,8 +1095,7 @@ bool CAdminSystem::ApplyInfractions(ZEPlayer *player)
 	{
 		// Because this can run without the player being authenticated, and the fact that we're applying a ban/mute here,
 		// we can immediately just use the steamid we got from the connecting player.
-		uint64 iSteamID = player->IsAuthenticated() ? 
-			player->GetSteamId64() : g_pEngineServer2->GetClientSteamID(player->GetPlayerSlot())->ConvertToUint64();
+		uint64 iSteamID = player->IsAuthenticated() ? player->GetSteamId64() : player->GetUnauthenticatedSteamId64();
 
 		// We're only interested in infractions concerning this player
 		if (m_vecInfractions[i]->GetSteamId64() != iSteamID)

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -521,7 +521,7 @@ bool CS2Fixes::Hook_ClientConnect( CPlayerSlot slot, const char *pszName, uint64
 {
 	Message( "Hook_ClientConnect(%d, \"%s\", %lli, \"%s\", %d, \"%s\")\n", slot, pszName, xuid, pszNetworkID, unk1, pRejectReason->ToGrowable()->Get() );
 		
-	if (!g_playerManager->OnClientConnected(slot))
+	if (!g_playerManager->OnClientConnected(slot, xuid))
 		RETURN_META_VALUE(MRES_SUPERCEDE, false);
 
 	RETURN_META_VALUE(MRES_IGNORED, true);

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -128,13 +128,14 @@ void CPlayerManager::OnBotConnected(CPlayerSlot slot)
 	m_vecPlayers[slot.Get()] = new ZEPlayer(slot, true);
 }
 
-bool CPlayerManager::OnClientConnected(CPlayerSlot slot)
+bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid)
 {
 	Assert(m_vecPlayers[slot.Get()] == nullptr);
 
 	Message("%d connected\n", slot.Get());
 
 	ZEPlayer *pPlayer = new ZEPlayer(slot);
+	pPlayer->SetUnauthenticatedSteamId(new CSteamID(xuid));
 
 	if (!g_pAdminSystem->ApplyInfractions(pPlayer))
 	{
@@ -170,7 +171,7 @@ void CPlayerManager::OnLateLoad()
 		if (!pController || !pController->IsController() || !pController->IsConnected())
 			continue;
 
-		OnClientConnected(i);
+		OnClientConnected(i, pController->m_steamID());
 	}
 }
 
@@ -187,8 +188,8 @@ void CPlayerManager::TryAuthenticate()
 		if (g_pEngineServer2->IsClientFullyAuthenticated(i))
 		{
 			m_vecPlayers[i]->SetAuthenticated();
-			m_vecPlayers[i]->SetSteamId(g_pEngineServer2->GetClientSteamID(i));
-			Message("%lli authenticated %d\n", m_vecPlayers[i]->GetSteamId()->ConvertToUint64(), i);
+			m_vecPlayers[i]->SetSteamId(m_vecPlayers[i]->GetUnauthenticatedSteamId());
+			Message("%lli authenticated %d\n", m_vecPlayers[i]->GetSteamId64(), i);
 			m_vecPlayers[i]->OnAuthenticated();
 		}
 	}

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -62,6 +62,8 @@ public:
 	bool IsFakeClient() { return m_bFakeClient; }
 	bool IsAuthenticated() { return m_bAuthenticated; }
 	bool IsConnected() { return m_bConnected; }
+	uint64 GetUnauthenticatedSteamId64() { return m_UnauthenticatedSteamID->ConvertToUint64(); }
+	const CSteamID* GetUnauthenticatedSteamId() { return m_UnauthenticatedSteamID; }
 	uint64 GetSteamId64() { return m_SteamID->ConvertToUint64(); }
 	const CSteamID* GetSteamId() { return m_SteamID; }
 	bool IsAdminFlagSet(uint64 iFlag);
@@ -69,6 +71,7 @@ public:
 	
 	void SetAuthenticated() { m_bAuthenticated = true; }
 	void SetConnected() { m_bConnected = true; }
+	void SetUnauthenticatedSteamId(const CSteamID* steamID) { m_UnauthenticatedSteamID = steamID; }
 	void SetSteamId(const CSteamID* steamID) { m_SteamID = steamID; }
 	uint64 GetAdminFlags() { return m_iAdminFlags; }
 	void SetAdminFlags(uint64 iAdminFlags) { m_iAdminFlags = iAdminFlags; }
@@ -106,6 +109,7 @@ public:
 private:
 	bool m_bAuthenticated;
 	bool m_bConnected;
+	const CSteamID* m_UnauthenticatedSteamID;
 	const CSteamID* m_SteamID;
 	bool m_bFakeClient;
 	bool m_bMuted;
@@ -139,7 +143,7 @@ public:
 			OnLateLoad();
 	}
 
-	bool OnClientConnected(CPlayerSlot slot);
+	bool OnClientConnected(CPlayerSlot slot, uint64 xuid);
 	void OnClientDisconnect(CPlayerSlot slot);
 	void OnBotConnected(CPlayerSlot slot);
 	void OnLateLoad();


### PR DESCRIPTION
- Fixed `c_reload_admins` crashing if anybody connected to the server was unauthenticated
- Fixed mutes, gags & bans crashing if the target was unauthenticated
- Replaced usages of `g_pEngineServer2->GetClientSteamID()` as it can be null, instead we store initial `xuid` value