### PR TITLE
Fix hide

### DIFF
--- a/src/cs2_sdk/entity/ccsplayercontroller.h
+++ b/src/cs2_sdk/entity/ccsplayercontroller.h
@@ -32,6 +32,7 @@ public:
 
 	SCHEMA_FIELD(CCSPlayerController_InGameMoneyServices*, m_pInGameMoneyServices)
 	SCHEMA_FIELD(CCSPlayerController_ActionTrackingServices*, m_pActionTrackingServices)
+	SCHEMA_FIELD(CHandle<CCSPlayerPawn>, m_hPlayerPawn)
 	SCHEMA_FIELD(bool, m_bPawnIsAlive);
 
 	static CCSPlayerController* FromPawn(CCSPlayerPawn* pawn) {
@@ -43,7 +44,9 @@ public:
 		return (CCSPlayerController*)g_pEntitySystem->GetBaseEntity(CEntityIndex(slot.Get() + 1));
 	}
 
-	ZEPlayer* GetZEPlayer()
+	CCSPlayerPawn *GetPlayerPawn() { return m_hPlayerPawn.Get(); }
+
+	ZEPlayer *GetZEPlayer()
 	{
 		return g_playerManager->GetPlayer(GetPlayerSlot());
 	}

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -261,7 +261,7 @@ void CPlayerManager::CheckHideDistances()
 
 			if (pTargetController)
 			{
-				auto pTargetPawn = pTargetController->GetPawn();
+				auto pTargetPawn = pTargetController->GetPlayerPawn();
 
 				// TODO: Unhide dead pawns if/when valve fixes the crash
 				if (pTargetPawn && (!g_bHideTeammatesOnly || pTargetController->m_iTeamNum == team))


### PR DESCRIPTION
`m_hPawn` points to an observer some time after death, so get `m_hPlayerPawn` instead to ensure that dead players are never transmitted.

**EDIT:** Clients will still crash if they themselves died at the end of a round, so until then hide should not be used on ZE servers or any others that disable respawn. This PR will remain unmerged until a we figure out a fix or Valve does.