### PR TITLE
Miscellaneous changes

### DIFF
--- a/CS2Fixes.vcxproj
+++ b/CS2Fixes.vcxproj
@@ -214,12 +214,14 @@
     <ClInclude Include="src\discord.h" />
     <ClInclude Include="src\eventlistener.h" />
     <ClInclude Include="src\gamesystem.h" />
+    <ClInclude Include="src\gameconfig.h" />
     <ClInclude Include="src\httpmanager.h" />
     <ClInclude Include="src\mempatch.h" />
     <ClInclude Include="src\addresses.h" />
     <ClInclude Include="src\playermanager.h" />
     <ClInclude Include="src\recipientfilters.h" />
     <ClInclude Include="src\votemanager.h" />
+    <ClInclude Include="src\map_votes.h" />
     <ClInclude Include="src\utils\entity.h" />
     <ClInclude Include="src\utils\module.h" />
     <ClInclude Include="src\utils\plat.h" />

--- a/CS2Fixes.vcxproj.filters
+++ b/CS2Fixes.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -203,6 +203,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\gamesystem.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\gameconfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\map_votes.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -31,6 +31,8 @@ cs2f_extend_success_ratio 		0.5		// Ratio needed to pass an extend
 cs2f_extend_time 				20		// Time to add per extend
 cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
 cs2f_rtv_endround				0		// Whether to immediately end the round when RTV succeeds
+cs2f_vote_maps_cooldown			10		// Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
+cs2f_vote_max_nominations		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // Ztele settings
 zr_ztele_max_distance 			150.0	// Maximum distance players are allowed to move after starting ztele

--- a/configs/admins.cfg.example
+++ b/configs/admins.cfg.example
@@ -23,9 +23,9 @@ Admins
 {
 	// Admin entries should follow this format
 	
-    //"name" // Unused, can be anything
-    //{
-    //    "steamid" "1234567890" // SteamID64
-    //    "flags" "abcdefg" // Permission flags as described above
-    //}
+	//"name" // Unused, can be anything
+	//{
+	//	"steamid" "1234567890" // SteamID64
+	//	"flags" "abcdefg" // Permission flags as described above
+	//}
 }

--- a/configs/discordbots.cfg.example
+++ b/configs/discordbots.cfg.example
@@ -3,11 +3,12 @@
 	"YourFirstBot"
 	{
 		"webhook" "DISCORD_WEBHOOK_1"
-		"avatar" "AVATAR_IMAGE_1"
+		"override_name" "false"
 	}
 	"YourSecondBot"
 	{
 		"webhook" "DISCORD_WEBHOOK_2"
 		"avatar" "AVATAR_IMAGE_2"
+		"override_name" "true"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -1,18 +1,18 @@
 "Maplist"
 {
-    "ze_my_first_ze_map"
-    {
-        "workshop_id" "123"
-	   "enabled" "1"
-    }
-    "ze_my_second_ze_map"
-    {
-        "workshop_id" "456"
-	   "enabled" "1"
-    }
-    "ze_my_thirdd_ze_map"
-    {
-        "workshop_id" "789"
-	   "enabled" "1"
-    }
+	"ze_my_first_ze_map"
+	{
+		"workshop_id" "123"
+		"enabled" "1"
+	}
+	"ze_my_second_ze_map"
+	{
+		"workshop_id" "456"
+		"enabled" "1"
+	}
+	"ze_my_thirdd_ze_map"
+	{
+		"workshop_id" "789"
+		"enabled" "1"
+	}
 }

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -748,18 +748,9 @@ CON_COMMAND_CHAT(setinteraction, "set a player's interaction flags")
 	}
 }
 
-void HttpCallback(HTTPRequestHandle request, char* response)
+void HttpCallback(HTTPRequestHandle request, json response)
 {
-	// Test serializing to JSON
-	json data = json::parse(response, nullptr, false);
-
-	if (data.is_discarded())
-	{
-		Message("Failed parsing JSON!\n");
-		return;
-	}
-
-	ClientPrintAll(HUD_PRINTTALK, data.dump().c_str());
+	ClientPrintAll(HUD_PRINTTALK, response.dump().c_str());
 }
 
 CON_COMMAND_CHAT(http, "test an HTTP request")

--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -757,26 +757,18 @@ CON_COMMAND_CHAT(http, "test an HTTP request")
 {
 	if (!g_http)
 	{
-		if (player)
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Steam HTTP interface is not available!");
-		else
-			Message("Steam HTTP interface is not available!\n");
-
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Steam HTTP interface is not available!");
 		return;
 	}
 	if (args.ArgC() < 3)
 	{
-		if (player)
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !http <get/post> <url> [content]");
-		else
-			Message("Usage: !http <get/post> <url> [content]\n");
-
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Usage: !http <get/post> <url> [content]");
 		return;
 	}
 
-	if (strcmp(args[1], "get") == 0)
+	if (!V_strcmp(args[1], "get"))
 		g_HTTPManager.GET(args[2], &HttpCallback);
-	else if (strcmp(args[1], "post") == 0)
+	else if (!V_strcmp(args[1], "post"))
 		g_HTTPManager.POST(args[2], args[3], &HttpCallback);
 }
 

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -531,7 +531,7 @@ bool CS2Fixes::Hook_ClientConnect( CPlayerSlot slot, const char *pszName, uint64
 {
 	Message( "Hook_ClientConnect(%d, \"%s\", %lli, \"%s\", %d, \"%s\")\n", slot, pszName, xuid, pszNetworkID, unk1, pRejectReason->ToGrowable()->Get() );
 		
-	if (!g_playerManager->OnClientConnected(slot, xuid))
+	if (!g_playerManager->OnClientConnected(slot, xuid, pszNetworkID))
 		RETURN_META_VALUE(MRES_SUPERCEDE, false);
 
 	RETURN_META_VALUE(MRES_IGNORED, true);

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -42,10 +42,10 @@ CON_COMMAND_F(cs2f_debug_discord_messages, "Whether to include debug information
 		g_bDebugDiscordRequests = V_StringToBool(args[1], false);
 }
 
-void DiscordHttpCallback(HTTPRequestHandle request, char* response)
+void DiscordHttpCallback(HTTPRequestHandle request, json response)
 {
 	if (g_bDebugDiscordRequests) {
-		Message("Discord post received response: %s\n", response);
+		Message("Discord post received response: %s\n", response.dump().c_str());
 	}
 }
 

--- a/src/discord.cpp
+++ b/src/discord.cpp
@@ -69,8 +69,12 @@ void CDiscordBot::PostMessage(const char* sMessage) {
 
 	// Fill up the Json fields
 	jRequestBody["content"] = sMessage;
-	jRequestBody["username"] = m_pszName;
-	jRequestBody["avatar_url"] = m_pszAvatarUrl;
+
+	if (m_bOverrideName)
+		jRequestBody["username"] = m_pszName;
+
+	if (V_strcmp(m_pszAvatarUrl, ""))
+		jRequestBody["avatar_url"] = m_pszAvatarUrl;
 
 	// Send the request
 	const char* sRequestBody = jRequestBody.dump().c_str();
@@ -97,6 +101,7 @@ bool CDiscordBotManager::LoadDiscordBotsConfig()
 		const char* pszName = pKey->GetName();
 		const char* pszWebhookUrl = pKey->GetString("webhook", nullptr);
 		const char* pszAvatarUrl = pKey->GetString("avatar", nullptr);
+		bool bOverrideName = pKey->GetBool("override_name", false);
 
 		if (!pszWebhookUrl)
 		{
@@ -105,13 +110,10 @@ bool CDiscordBotManager::LoadDiscordBotsConfig()
 		}
 
 		if (!pszAvatarUrl)
-		{
-			Warning("Discord bot entry %s is missing 'avatar' key\n", pszName);
-			return false;
-		}
+			pszAvatarUrl = "";
 
 		// We just append the bots as-is
-		CDiscordBot bot = CDiscordBot(pszName, pszWebhookUrl, pszAvatarUrl);
+		CDiscordBot bot = CDiscordBot(pszName, pszWebhookUrl, pszAvatarUrl, bOverrideName);
 		ConMsg("Loaded DiscordBot config %s\n", bot.GetName());
 		ConMsg(" - Webhook URL: %s\n", bot.GetWebhookUrl());
 		ConMsg(" - Avatar URL: %s\n", bot.GetAvatarUrl());

--- a/src/discord.h
+++ b/src/discord.h
@@ -23,11 +23,12 @@
 class CDiscordBot
 {
 public:
-	CDiscordBot(const char* pszName, const char* pszWebhookUrl, const char* pszAvatarUrl)
+	CDiscordBot(const char* pszName, const char* pszWebhookUrl, const char* pszAvatarUrl, bool bOverrideName)
 	{
 		V_strcpy(m_pszName, pszName);
 		V_strcpy(m_pszWebhookUrl, pszWebhookUrl);
 		V_strcpy(m_pszAvatarUrl, pszAvatarUrl);
+		m_bOverrideName = bOverrideName;
 	}
 
 	const char* GetName() { return (const char*)m_pszName; };
@@ -39,6 +40,7 @@ private:
 	char m_pszName[32];
 	char m_pszWebhookUrl[256];
 	char m_pszAvatarUrl[256];
+	bool m_bOverrideName;
 };
 
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -23,9 +23,9 @@
 #include "ctimer.h"
 #include "eventlistener.h"
 #include "entity/cbaseplayercontroller.h"
+#include "playermanager.h"
 
 #include "tier0/memdbgon.h"
-#include "playermanager.h"
 
 extern IGameEventManager2 *g_gameEventManager;
 extern IServerGameClients *g_pSource2GameClients;

--- a/src/httpmanager.h
+++ b/src/httpmanager.h
@@ -28,29 +28,33 @@
 #pragma once
 
 #include "cs2fixes.h"
+#undef snprintf
+#include "vendor/nlohmann/json.hpp"
 #include <steam/steam_gameserver.h>
 
 #include <vector>
 #include <functional>
 
+using json = nlohmann::json;
+
 class HTTPManager;
 extern HTTPManager g_HTTPManager;
 
-#define CompletedCallback std::function<void(HTTPRequestHandle, char*)>
+#define CompletedCallback std::function<void(HTTPRequestHandle, json)>
 
 class HTTPHeader
 {
 public:
-	HTTPHeader(const char* pszName, const char* pszValue)
+	HTTPHeader(std::string strName, std::string strValue)
 	{
-		m_pszName = pszName;
-		m_pszValue = pszValue;
+		m_strName = strName;
+		m_strValue = strValue;
 	}
-	const char* GetName() { return m_pszName; }
-	const char* GetValue() { return m_pszValue; }
+	const char* GetName() { return m_strName.c_str(); }
+	const char* GetValue() { return m_strValue.c_str(); }
 private:
-	const char* m_pszName;
-	const char* m_pszValue;
+	std::string m_strName;
+	std::string m_strValue;
 };
 
 class HTTPManager
@@ -65,15 +69,15 @@ private:
 	{
 	public:
 		TrackedRequest(const TrackedRequest& req) = delete;
-		TrackedRequest(HTTPRequestHandle hndl, SteamAPICall_t hCall, const char* pszUrl, const char* pszText, CompletedCallback callback);
+		TrackedRequest(HTTPRequestHandle hndl, SteamAPICall_t hCall, std::string strUrl, std::string strText, CompletedCallback callback);
 		~TrackedRequest();
 	private:
 		void OnHTTPRequestCompleted(HTTPRequestCompleted_t* arg, bool bFailed);
 
 		HTTPRequestHandle m_hHTTPReq;
 		CCallResult<TrackedRequest, HTTPRequestCompleted_t> m_CallResult;
-		char* m_pszUrl;
-		char* m_pszText;
+		std::string m_strUrl;
+		std::string m_strText;
 		CompletedCallback m_callback;
 	};
 private:

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -73,7 +73,7 @@ CON_COMMAND_F(cs2f_vote_max_nominations, "Number of nominations to include per v
 	}
 }
 
-CON_COMMAND_CHAT_FLAGS(setnextmap, "Force next map", ADMFLAG_ROOT)
+CON_COMMAND_CHAT_FLAGS(setnextmap, "Force next map", ADMFLAG_CHANGEMAP)
 {
 	bool bIsClearingForceNextMap = args.ArgC() < 2;
 	int iResponse = g_pMapVoteSystem->ForceNextMap(bIsClearingForceNextMap ? "" : args[1]);
@@ -123,7 +123,7 @@ static int __cdecl OrderStringsLexicographically(const char* const* a, const cha
 	return V_strcasecmp(*a, *b);
 }
 
-CON_COMMAND_CHAT_FLAGS(maplist, "List the maps in the server", ADMFLAG_NONE)
+CON_COMMAND_CHAT(maplist, "List the maps in the server")
 {
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "The list of all maps will be shown in console.");
 	ClientPrint(player, HUD_PRINTCONSOLE, "The list of all maps is:");
@@ -137,7 +137,7 @@ CON_COMMAND_CHAT_FLAGS(maplist, "List the maps in the server", ADMFLAG_NONE)
 	}
 }
 
-CON_COMMAND_CHAT_FLAGS(nomlist, "List the list of nominations", ADMFLAG_NONE)
+CON_COMMAND_CHAT(nomlist, "List the list of nominations")
 {
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Current nominations:");
 	for (int i = 0; i < g_pMapVoteSystem->GetMapListSize(); i++) {
@@ -149,7 +149,7 @@ CON_COMMAND_CHAT_FLAGS(nomlist, "List the list of nominations", ADMFLAG_NONE)
 	}
 }
 
-CON_COMMAND_CHAT_FLAGS(mapcooldowns, "List the maps currently in cooldown", ADMFLAG_NONE)
+CON_COMMAND_CHAT(mapcooldowns, "List the maps currently in cooldown")
 {
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "The list of maps in cooldown will be shown in console.");
 	ClientPrint(player, HUD_PRINTCONSOLE, "The list of maps in cooldown is:");

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -129,7 +129,7 @@ void CPlayerManager::OnBotConnected(CPlayerSlot slot)
 	m_vecPlayers[slot.Get()] = new ZEPlayer(slot, true);
 }
 
-bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid)
+bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid, const char* pszNetworkID)
 {
 	Assert(m_vecPlayers[slot.Get()] == nullptr);
 
@@ -137,6 +137,20 @@ bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid)
 
 	ZEPlayer *pPlayer = new ZEPlayer(slot);
 	pPlayer->SetUnauthenticatedSteamId(new CSteamID(xuid));
+
+	std::string ip(pszNetworkID);
+
+	// Remove port
+	for (int i = 0; i < ip.length(); i++)
+	{
+		if (ip[i] == ':')
+		{
+			ip = ip.substr(0, i);
+			break;
+		}
+	}
+
+	pPlayer->SetIpAddress(ip);
 
 	if (!g_pAdminSystem->ApplyInfractions(pPlayer))
 	{
@@ -176,7 +190,7 @@ void CPlayerManager::OnLateLoad()
 		if (!pController || !pController->IsController() || !pController->IsConnected())
 			continue;
 
-		OnClientConnected(i, pController->m_steamID());
+		OnClientConnected(i, pController->m_steamID(), "0.0.0.0:0");
 	}
 }
 

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -88,6 +88,7 @@ public:
 	void SetRTVVoteTime(float flCurtime) { m_flRTVVoteTime = flCurtime; }
 	void SetExtendVote(bool bExtendVote) { m_bVotedExtend = bExtendVote; }
 	void SetExtendVoteTime(float flCurtime) { m_flExtendVoteTime = flCurtime; }
+	void SetIpAddress(std::string strIp) { m_strIp = strIp; }
 
 	bool IsMuted() { return m_bMuted; }
 	bool IsGagged() { return m_bGagged; }
@@ -101,6 +102,7 @@ public:
 	float GetRTVVoteTime() { return m_flRTVVoteTime; }
 	bool GetExtendVote() { return m_bVotedExtend; }
 	float GetExtendVoteTime() { return m_flExtendVoteTime; }
+	const char* GetIpAddress() { return m_strIp.c_str(); }
 	
 	void OnAuthenticated();
 	void CheckAdmin();
@@ -127,6 +129,7 @@ private:
 	float m_flExtendVoteTime;
 	int m_iFloodTokens;
 	float m_flLastTalkTime;
+	std::string m_strIp;
 };
 
 class CPlayerManager
@@ -143,7 +146,7 @@ public:
 			OnLateLoad();
 	}
 
-	bool OnClientConnected(CPlayerSlot slot, uint64 xuid);
+	bool OnClientConnected(CPlayerSlot slot, uint64 xuid, const char* pszNetworkID);
 	void OnClientDisconnect(CPlayerSlot slot);
 	void OnBotConnected(CPlayerSlot slot);
 	void OnLateLoad();

--- a/src/votemanager.cpp
+++ b/src/votemanager.cpp
@@ -367,7 +367,7 @@ CON_COMMAND_CHAT(ve, "Vote to extend the current map.")
 			flTimelimit = 1;
 		
 		char buf[32];
-		V_snprintf(buf, sizeof(buf), "mp_timelimit %.6f", flTimelimit + g_iExtendTimeToAdd);
+		V_snprintf(buf, sizeof(buf), "mp_timelimit %.6f", flTimelimit);
 
 		// CONVAR_TODO
 		g_pEngineServer2->ServerCommand(buf);
@@ -380,8 +380,8 @@ CON_COMMAND_CHAT(ve, "Vote to extend the current map.")
 			// there's an extend left after a successfull extend vote
 			g_ExtendState = EExtendState::POST_EXTEND_COOLDOWN;
 
-			// Allow another extend vote after 2 minutes
-			new CTimer(120.0f, false, []()
+			// Allow another extend vote after added time lapses
+			new CTimer(g_iExtendTimeToAdd * 60.0f, false, []()
 			{
 				if (g_ExtendState == EExtendState::POST_EXTEND_COOLDOWN)
 					g_ExtendState = EExtendState::EXTEND_ALLOWED;


### PR DESCRIPTION
- Fixed extend time being applied twice
- Fixed extend votes being able to be rapidly chained when more than one is available
- Allowed Discord webhooks to not override default settings
- Added player IP tracking
- Deduplicated JSON parsing code
- Switched to safer method of string storage in HTTPHeader & TrackedRequest classes
- Added missing header files to VS project files
- Added missing map vote cvars to cs2fixes.cfg
- Made config file formatting consistent
- Some code cleanup in c_http debug command
- Fixed memdbgon.h not being last include in events.cpp
- Fixed !setnextmap not having correct admin flag
- Switched to simpler CON_COMMAND_CHAT macro for most map vote commands