### PR TITLE
Add Console chat timers for map triggers

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -10,6 +10,7 @@ cs2f_use_old_push 				0		// Whether to use the old CSGO trigger_push behavior (N
 cs2f_hide_enable 				0		// Whether to enable hide
 cs2f_votemanager_enable			1		// Whether to enable votemanager features such as RTV and extends
 zr_ztele_enable 				0		// Whether to enable ztele
+cs2f_trigger_timer_enable       0       // Whether to process countdown messages said by Console (e.g. Hold for 10 seconds) and append the round time where the countdown resolves
 
 // Damage block settings
 cs2f_block_molotov_self_dmg 	0		// Whether to block self-damage from molotovs

--- a/src/cs2_sdk/entity/cgamerules.h
+++ b/src/cs2_sdk/entity/cgamerules.h
@@ -40,6 +40,7 @@ public:
 	SCHEMA_FIELD(GameTime_t, m_flRestartRoundTime)
 	SCHEMA_FIELD_POINTER(int, m_nEndMatchMapGroupVoteOptions)
 	SCHEMA_FIELD(int, m_nEndMatchMapVoteWinner)
+	SCHEMA_FIELD(int, m_iRoundTime)
 };
 
 class CCSGameRulesProxy : public Z_CBaseEntity


### PR DESCRIPTION
This feature adds a timestamp to console chat for trigger countdowns, letting players know when the countdown will end at a glance. This feature can be toggled using the new cvar `cs2f_trigger_timer_enable`.

![image](https://github.com/Source2ZE/CS2Fixes/assets/124469923/fb7dd3c8-69f4-4ece-852b-c3ba15748203)

The timer will not display if the countdown is shorter than 5 seconds, or the countdown is longer than the remaining round time.