### PR TITLE
Fix crash when try to access inavlid ZEPlayer*

### DIFF
--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -135,6 +135,11 @@ CON_COMMAND_CHAT_FLAGS(ban, "ban a player", ADMFLAG_BAN)
 
 	ZEPlayer* pTargetPlayer = g_playerManager->GetPlayer(pSlot[0]);
 
+	if(!pTargetPlayer){
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
+		return;
+	}
+
 	if (pTargetPlayer->IsFakeClient())
 		return;
 
@@ -213,6 +218,11 @@ CON_COMMAND_CHAT_FLAGS(mute, "mutes a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer* pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
+		
+		if(!pTargetPlayer){
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
+			continue;
+		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
@@ -272,6 +282,11 @@ CON_COMMAND_CHAT_FLAGS(unmute, "unmutes a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
+		
+		if(!pTargetPlayer){
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
+			continue;
+		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
@@ -339,6 +354,11 @@ CON_COMMAND_CHAT_FLAGS(gag, "gag a player", ADMFLAG_CHAT)
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
 
+		if(!pTargetPlayer){
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
+			continue;
+		}
+
 		if (pTargetPlayer->IsFakeClient())
 			continue;
 
@@ -399,6 +419,11 @@ CON_COMMAND_CHAT_FLAGS(ungag, "ungags a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
+
+		if(!pTargetPlayer){
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
+			continue;
+		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -135,11 +135,6 @@ CON_COMMAND_CHAT_FLAGS(ban, "ban a player", ADMFLAG_BAN)
 
 	ZEPlayer* pTargetPlayer = g_playerManager->GetPlayer(pSlot[0]);
 
-	if(!pTargetPlayer){
-		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
-		return;
-	}
-
 	if (pTargetPlayer->IsFakeClient())
 		return;
 
@@ -218,11 +213,6 @@ CON_COMMAND_CHAT_FLAGS(mute, "mutes a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer* pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
-		
-		if(!pTargetPlayer){
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
-			continue;
-		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
@@ -282,11 +272,6 @@ CON_COMMAND_CHAT_FLAGS(unmute, "unmutes a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
-		
-		if(!pTargetPlayer){
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
-			continue;
-		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;
@@ -354,11 +339,6 @@ CON_COMMAND_CHAT_FLAGS(gag, "gag a player", ADMFLAG_CHAT)
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
 
-		if(!pTargetPlayer){
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
-			continue;
-		}
-
 		if (pTargetPlayer->IsFakeClient())
 			continue;
 
@@ -419,11 +399,6 @@ CON_COMMAND_CHAT_FLAGS(ungag, "ungags a player", ADMFLAG_CHAT)
 			continue;
 
 		ZEPlayer *pTargetPlayer = g_playerManager->GetPlayer(pSlot[i]);
-
-		if(!pTargetPlayer){
-			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "%s is invalid, target is kicked from server?", pTarget->GetPlayerName());
-			continue;
-		}
 
 		if (pTargetPlayer->IsFakeClient())
 			continue;

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -335,7 +335,7 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 
 			CCSPlayerController* player = CCSPlayerController::FromSlot(i);
 
-			if (!player || !player->IsController())
+			if (!player || !player->IsController() || !player->IsConnected())
 				continue;
 
 			if (player->m_iTeamNum() != (targetType == ETargetType::T ? CS_TEAM_T : CS_TEAM_CT))
@@ -360,7 +360,7 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 
 			CCSPlayerController* player = CCSPlayerController::FromSlot(slot);
 
-			if (!player)
+			if (!player || !player->IsController() || !player->IsConnected())
 				continue;
 
 			if (targetType >= ETargetType::RANDOM_T && (player->m_iTeamNum() != (targetType == ETargetType::RANDOM_T ? CS_TEAM_T : CS_TEAM_CT)))
@@ -390,7 +390,7 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 
 			CCSPlayerController* player = CCSPlayerController::FromSlot(i);
 
-			if (!player || !player->IsController())
+			if (!player || !player->IsController() || !player->IsConnected())
 				continue;
 
 			if (V_stristr(player->GetPlayerName(), target))

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -376,7 +376,9 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 		if (userid != -1)
 		{
 			targetType = ETargetType::PLAYER;
-			clients[iNumClients++] = GetSlotFromUserId(userid).Get();
+			CCSPlayerController* player = CCSPlayerController::FromSlot(GetSlotFromUserId(userid).Get());
+			if(player && player->IsController() && player->IsConnected())
+				clients[iNumClients++] = GetSlotFromUserId(userid).Get();
 		}
 	}
 	else

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -323,6 +323,11 @@ ETargetType CPlayerManager::TargetPlayerString(int iCommandClient, const char* t
 			if (m_vecPlayers[i] == nullptr)
 				continue;
 
+			CCSPlayerController* player = CCSPlayerController::FromSlot(i);
+
+			if (!player || !player->IsController() || !player->IsConnected())
+				continue;
+
 			clients[iNumClients++] = i;
 		}
 	}


### PR DESCRIPTION
It accesses a nullptr and cause crashes.

You can probably make it happen by using the kick and mute commands simultaneously.

