### PR TITLE
Feat: Add warning messages for classic spawns

### DIFF
--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -559,6 +559,8 @@ void SetupCTeams()
 void ZR_OnRoundStart(IGameEvent* pEvent)
 {
 	ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.");
+	if (g_iInfectSpawnType != EZRSpawnType::RESPAWN)
+		ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "Warning! Zombies will be spawning between humans!");
 	SetupRespawnToggler();
 	CZRRegenTimer::RemoveAllTimers();
 }
@@ -857,7 +859,10 @@ void ZR_StartInitialCountdown()
 		if (g_iInfectionCountDown <= 60)
 		{
 			char message[256];
-			V_snprintf(message, sizeof(message), "First infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
+			if (g_iInfectSpawnType != EZRSpawnType::RESPAWN)
+				V_snprintf(message, sizeof(message), "Warning! Zombies will be spawning between humans!\nFirst infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
+			else
+				V_snprintf(message, sizeof(message), "First infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
 
 			ClientPrintAll(HUD_PRINTCENTER, message);
 			if (g_iInfectionCountDown % 5 == 0)

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -560,7 +560,7 @@ void ZR_OnRoundStart(IGameEvent* pEvent)
 {
 	ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.");
 	if (g_iInfectSpawnType != EZRSpawnType::RESPAWN)
-		ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "Warning! Zombies will be spawning between humans!");
+		ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "Classic spawns enabled! Zombies will be \x07spawning between humans\x01!");
 	SetupRespawnToggler();
 	CZRRegenTimer::RemoveAllTimers();
 }
@@ -860,7 +860,7 @@ void ZR_StartInitialCountdown()
 		{
 			char message[256];
 			if (g_iInfectSpawnType != EZRSpawnType::RESPAWN)
-				V_snprintf(message, sizeof(message), "Warning! Zombies will be spawning between humans!\nFirst infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
+				V_snprintf(message, sizeof(message), "Classic spawns enabled! Zombies will be spawning between humans!\nFirst infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
 			else
 				V_snprintf(message, sizeof(message), "First infection in \7%i %s\1!", g_iInfectionCountDown, g_iInfectionCountDown == 1 ? "second" : "seconds");
 


### PR DESCRIPTION
QoL change to give new players a heads-up warning if zombies will be spawning between humans, aka "classic spawns."

Feedback is appreciated and welcome as to how this should be properly implemented. Some ideas are taken from CSS.