### PR TITLE
Zombie Muting

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -70,4 +70,4 @@ zr_zombie_win_overlay_particle	""		//Screenspace particle to display when zombie
 zr_zombie_win_overlay_material	""		//Material override for zombie's win overlay particle
 zr_zombie_win_overlay_size		100		//Size of zombie's win overlay particle
 zr_zombie_mute                  0       // Mute zombies to prevent them from disrupting humsns
-zr_zombie_mute_bypass           "abj"      // A list of admin flags that can bypass the zombie mute ('z' disables zombie muting!)
+zr_zombie_mute_bypass           "abj"   // A list of admin flags that can bypass the zombie mute ('z' disables zombie muting!)

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -69,5 +69,5 @@ zr_human_win_overlay_size		100		//Size of human's win overlay particle
 zr_zombie_win_overlay_particle	""		//Screenspace particle to display when zombie win
 zr_zombie_win_overlay_material	""		//Material override for zombie's win overlay particle
 zr_zombie_win_overlay_size		100		//Size of zombie's win overlay particle
-zr_zombie_mute                  0       // Mute zombies to prevent them from disrupting humsns
-zr_zombie_mute_bypass           "abj"   // A list of admin flags that can bypass the zombie mute ('z' disables zombie muting!)
+zr_zombie_mute					0		// Mute zombies to prevent them from disrupting humans
+zr_zombie_mute_bypass			"abj"	// A list of admin flags that can bypass the zombie mute ('z' disables zombie muting!)

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -69,3 +69,5 @@ zr_human_win_overlay_size		100		//Size of human's win overlay particle
 zr_zombie_win_overlay_particle	""		//Screenspace particle to display when zombie win
 zr_zombie_win_overlay_material	""		//Material override for zombie's win overlay particle
 zr_zombie_win_overlay_size		100		//Size of zombie's win overlay particle
+zr_zombie_mute                  0       // Mute zombies to prevent them from disrupting humsns
+zr_zombie_mute_bypass           "abj"      // A list of admin flags that can bypass the zombie mute ('z' disables zombie muting!)

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -1302,6 +1302,19 @@ bool CAdminSystem::FindAndRemoveInfraction(ZEPlayer *player, CInfractionBase::EI
 	return false;
 }
 
+bool CAdminSystem::HasInfraction(ZEPlayer *player, CInfractionBase::EInfractionType type)
+{
+	FOR_EACH_VEC(m_vecInfractions, i)
+	{
+		if (m_vecInfractions[i]->GetSteamId64() == player->GetSteamId64() && m_vecInfractions[i]->GetType() == type)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
 CAdmin *CAdminSystem::FindAdmin(uint64 iSteamID)
 {
 	FOR_EACH_VEC(m_vecAdmins, i)

--- a/src/adminsystem.h
+++ b/src/adminsystem.h
@@ -148,6 +148,12 @@ public:
 	void SaveInfractions();
 	bool ApplyInfractions(ZEPlayer *player);
 	bool FindAndRemoveInfraction(ZEPlayer *player, CInfractionBase::EInfractionType type);
+
+	/// @brief Determines if the player has an active infraction of the specified type
+	/// @param player 
+	/// @param type 
+	/// @return true if an active infraction is found
+	bool HasInfraction(ZEPlayer *player, CInfractionBase::EInfractionType type);
 	CAdmin *FindAdmin(uint64 iSteamID);
 	uint64 ParseFlags(const char* pszFlags);
 


### PR DESCRIPTION
Automatically mute players when they are infected to prevent them from talking over humans. Currently untested, but builds fine.

- `zr_zombie_mute <bool>` enables/disables zombie muting globally
- `zr_zombie_mute_bypass <adminflags>` sets adminflags that are allowed to speak as zombies