### PR TITLE
Fix friendly fire counting towards the Top Defender hit counter

### DIFF
--- a/src/events.cpp
+++ b/src/events.cpp
@@ -138,7 +138,7 @@ GAME_EVENT_F(player_hurt)
 	CCSPlayerController *pVictim = (CCSPlayerController*)pEvent->GetPlayerController("userid");
 
 	// Ignore Ts/zombies and CTs hurting themselves
-	if (!pAttacker || pAttacker->m_iTeamNum() != CS_TEAM_CT || pAttacker == pVictim)
+	if (!pAttacker || pAttacker->m_iTeamNum() != CS_TEAM_CT || pAttacker->m_iTeamNum() == pVictim->m_iTeamNum())
 		return;
 
 	ZEPlayer* pPlayer = pAttacker->GetZEPlayer();


### PR DESCRIPTION
A really funny way of accumulating a massive hit count while doing 0 damage.

It doesn't make sense to run the rest of the function when attacking a teammate. It didn't make a difference until the hit counter was added though.