### PR TITLE
Use Steam API callback to handle auth

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -16,8 +16,11 @@ cs2f_fix_lag_comp_crash			0		// Whether to fix lag compensation crash with env_e
 cs2f_flashlight_enable			0		// Whether to enable flashlights
 cs2f_infinite_reserve_ammo		0		// Whether to enable infinite reserve ammo on weapons
 cs2f_block_entity_strings		0		// Whether to block adding entries in the EntityNames stringtable
-cs2f_beacon_particle		    "particles/cs2fixes/player_beacon.vpcf" // .vpcf file to be precached and used for player beacon
 cs2f_disable_subtick_move		0		// Whether to disable subtick movement
+
+cs2f_beacon_particle		    "particles/cs2fixes/player_beacon.vpcf" // .vpcf file to be precached and used for player beacon
+
+cs2f_delay_auth_fail_kick		0		// How long in seconds to delay kicking players when their Steam authentication fails, use with sv_steamauth_enforce 0
 
 // Flashlight settings
 cs2f_flashlight_shadows			1		// Whether to enable flashlight shadows

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -259,13 +259,6 @@ bool CS2Fixes::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool
 
 	RegisterWeaponCommands();
 
-	// Steam authentication
-	new CTimer(1.0f, true, []()
-	{
-		g_playerManager->TryAuthenticate();
-		return 1.0f;
-	});
-
 	// Check hide distance
 	new CTimer(0.5f, true, []()
 	{
@@ -471,6 +464,8 @@ void CS2Fixes::Hook_GameServerSteamAPIActivated()
 {
 	g_steamAPI.Init();
 	g_http = g_steamAPI.SteamHTTP();
+
+	g_playerManager->OnSteamAPIActivated();
 
 	RETURN_META(MRES_IGNORED);
 }

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -20,7 +20,9 @@
 #pragma once
 #include "common.h"
 #include "utlvector.h"
+#include "steam/steam_api_common.h"
 #include "steam/steamclientpublic.h"
+#include "steam/isteamuser.h"
 #include <playerslot.h>
 #include "bitvec.h"
 #include "entity/lights.h"
@@ -136,7 +138,6 @@ public:
 	bool IsAdminFlagSet(uint64 iFlag);
 	bool IsFlooding();
 	
-	void SetAuthenticated() { m_bAuthenticated = true; }
 	void SetConnected() { m_bConnected = true; }
 	void SetUnauthenticatedSteamId(const CSteamID* steamID) { m_UnauthenticatedSteamID = steamID; }
 	void SetSteamId(const CSteamID* steamID) { m_SteamID = steamID; }
@@ -268,7 +269,7 @@ public:
 	void OnBotConnected(CPlayerSlot slot);
 	void OnClientPutInServer(CPlayerSlot slot);
 	void OnLateLoad();
-	void TryAuthenticate();
+	void OnSteamAPIActivated();
 	void CheckInfractions();
 	void FlashLightThink();
 	void CheckHideDistances();
@@ -295,6 +296,8 @@ public:
 	bool IsPlayerUsingStopDecals(int slot) { return m_nUsingStopDecals & ((uint64)1 << slot); }
 
 	void UpdatePlayerStates();
+
+	STEAM_GAMESERVER_CALLBACK_MANUAL(CPlayerManager, OnValidateAuthTicket, ValidateAuthTicketResponse_t, m_CallbackValidateAuthTicketResponse);
 
 private:
 	ZEPlayer *m_vecPlayers[MAXPLAYERS];


### PR DESCRIPTION
Rather than rely on a silly repeating timer, we use a callback to grab the response from the Steam servers right when it's done. By default, if the authentication fails it instantly kicks the player. So instead servers can disable the instant kick with `sv_steamauth_enforce 0` and display a warning to players, in case they have auth issues due to a game crash.