### PR TITLE
Add Idle Player Kicking System

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -77,6 +77,7 @@ for sdk_target in MMSPlugin.sdk_targets:
     'src/customio.cpp',
     'src/entitylistener.cpp',
     'src/leader.cpp',
+    'src/idlemanager.cpp',
     'sdk/entity2/entitysystem.cpp',
     'sdk/entity2/entityidentity.cpp',
     'sdk/entity2/entitykeyvalues.cpp',

--- a/CS2Fixes.vcxproj
+++ b/CS2Fixes.vcxproj
@@ -192,6 +192,7 @@
     <ClCompile Include="src\gameconfig.cpp" />
     <ClCompile Include="src\gamesystem.cpp" />
     <ClCompile Include="src\httpmanager.cpp" />
+    <ClCompile Include="src\idlemanager.cpp" />
     <ClCompile Include="src\map_votes.cpp" />
     <ClCompile Include="src\mempatch.cpp" />
     <ClCompile Include="src\patches.cpp" />
@@ -244,6 +245,7 @@
     <ClInclude Include="src\gamesystem.h" />
     <ClInclude Include="src\gameconfig.h" />
     <ClInclude Include="src\httpmanager.h" />
+    <ClInclude Include="src\idlemanager.h" />
     <ClInclude Include="src\mempatch.h" />
     <ClInclude Include="src\addresses.h" />
     <ClInclude Include="src\patches.h" />

--- a/CS2Fixes.vcxproj.filters
+++ b/CS2Fixes.vcxproj.filters
@@ -86,6 +86,9 @@
     <ClCompile Include="src\httpmanager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\idlemanager.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\votemanager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -221,6 +224,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\httpmanager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\idlemanager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\votemanager.h">

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -98,3 +98,8 @@ cs2f_leader_vote_ratio			0.15	// Vote ratio needed for player to become a leader
 cs2f_leader_actions_ct_only		1		// Whether to allow leader actions (like !beacon) only from human team
 cs2f_leader_mute_ping_no_leader	1		// Whether to mute player pings whenever there's no leader
 cs2f_leader_model_path			""		// Path to player model to be used for leaders
+
+// Idle Kick Settings
+cs2f_idle_kick_time				5.0		// Amount of minutes before kicking idle players
+cs2f_idle_kick_min_players		0		// Minimum amount of connected clients to kick idle players.
+cs2f_idle_kick_admins			"true"	// Whether to kick idle players with ADMFLAG_GENERIC

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -100,6 +100,6 @@ cs2f_leader_mute_ping_no_leader	1		// Whether to mute player pings whenever ther
 cs2f_leader_model_path			""		// Path to player model to be used for leaders
 
 // Idle Kick Settings
-cs2f_idle_kick_time				5.0		// Amount of minutes before kicking idle players
+cs2f_idle_kick_time				5.0		// Amount of minutes before kicking idle players. 0 to disable afk kicking.
 cs2f_idle_kick_min_players		0		// Minimum amount of connected clients to kick idle players.
 cs2f_idle_kick_admins			1		// Whether to kick idle players with ADMFLAG_GENERIC

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -102,4 +102,4 @@ cs2f_leader_model_path			""		// Path to player model to be used for leaders
 // Idle Kick Settings
 cs2f_idle_kick_time				5.0		// Amount of minutes before kicking idle players
 cs2f_idle_kick_min_players		0		// Minimum amount of connected clients to kick idle players.
-cs2f_idle_kick_admins			"true"	// Whether to kick idle players with ADMFLAG_GENERIC
+cs2f_idle_kick_admins			1		// Whether to kick idle players with ADMFLAG_GENERIC

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -643,6 +643,14 @@ void CS2Fixes::Hook_ClientCommand( CPlayerSlot slot, const CCommand &args )
 	Message( "Hook_ClientCommand(%d, \"%s\")\n", slot, args.GetCommandString() );
 #endif
 
+	if (g_fIdleKickTime > 0.0f)
+	{
+		ZEPlayer* pPlayer = g_playerManager->GetPlayer(slot);
+
+		if (pPlayer)
+			pPlayer->UpdateLastInputTime();
+	}
+
 	if (g_bVoteManagerEnable && V_stricmp(args[0], "endmatch_votenextmap") == 0 && args.ArgC() == 2)
 	{
 		if (g_pMapVoteSystem->RegisterPlayerVote(slot, atoi(args[1])))

--- a/src/gamesystem.cpp
+++ b/src/gamesystem.cpp
@@ -27,6 +27,7 @@
 #include "adminsystem.h"
 #include "entities.h"
 #include "tier0/vprof.h"
+#include "idlemanager.h"
 
 #include "tier0/memdbgon.h"
 
@@ -89,6 +90,7 @@ GS_EVENT_MEMBER(CGameSystem, ServerPreEntityThink)
 {
 	VPROF_BUDGET("CGameSystem::ServerPreEntityThink", "CS2FixesPerFrame")
 	g_playerManager->FlashLightThink();
+	g_pIdleSystem->UpdateIdleTimes();
 	EntityHandler_OnGameFramePre(gpGlobals->m_bInSimulation, gpGlobals->tickcount);
 }
 

--- a/src/idlemanager.cpp
+++ b/src/idlemanager.cpp
@@ -31,7 +31,7 @@ float g_fIdleKickTime = 5.0f;
 static int g_iMinClientsForIdleKicks = 0;
 static bool g_bKickAdmins = true;
 
-FAKE_FLOAT_CVAR(cs2f_idle_kick_time, "Amount of minutes (min. 3) before kicking idle players. 0 to disable afk kicking.", g_fIdleKickTime, 5.0f, false)
+FAKE_FLOAT_CVAR(cs2f_idle_kick_time, "Amount of minutes before kicking idle players. 0 to disable afk kicking.", g_fIdleKickTime, 5.0f, false)
 FAKE_INT_CVAR(cs2f_idle_kick_min_players, "Minimum amount of connected clients to kick idle players.", g_iMinClientsForIdleKicks, 0, false)
 FAKE_BOOL_CVAR(cs2f_idle_kick_admins, "Whether to kick idle players with ADMFLAG_GENERIC", g_bKickAdmins, true, false)
 

--- a/src/idlemanager.cpp
+++ b/src/idlemanager.cpp
@@ -57,8 +57,6 @@ void CIdleSystem::CheckForIdleClients()
 
 		if (!zPlayer || zPlayer->IsFakeClient())
 			continue;
-		
-		uint64 iIdleTime = static_cast<uint64>(std::time(0) - zPlayer->GetLastInputTime());
 
 		if (zPlayer->IsAuthenticated() && !g_bKickAdmins)
 		{
@@ -67,7 +65,7 @@ void CIdleSystem::CheckForIdleClients()
 				continue;
 		}
 
-		int iIdleTimeLeft = static_cast<uint64>(g_fIdleKickTime * 60) - iIdleTime;
+		int iIdleTimeLeft = static_cast<uint64>(g_fIdleKickTime * 60) - static_cast<uint64>(std::time(0) - zPlayer->GetLastInputTime());
 
 		if (iIdleTimeLeft > 0)
 		{

--- a/src/idlemanager.h
+++ b/src/idlemanager.h
@@ -19,11 +19,14 @@
 
 #pragma once
 
+extern float g_fIdleKickTime;
+
 class CIdleSystem
 {
 public:
 	CIdleSystem() {}
 	void CheckForIdleClients();
+	void UpdateIdleTimes();
 	void PauseIdleChecks() { m_bPaused = true; }
 	void Reset();
 private:

--- a/src/idlemanager.h
+++ b/src/idlemanager.h
@@ -1,0 +1,33 @@
+/**
+* =============================================================================
+* CS2Fixes
+* Copyright (C) 2023-2024 Source2ZE
+* =============================================================================
+*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License, version 3.0, as published by the
+* Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+* FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+* details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+class CIdleSystem
+{
+public:
+	CIdleSystem() {}
+	void CheckForIdleClients();
+	void PauseIdleChecks() { m_bPaused = true; }
+	void Reset();
+private:
+	bool m_bPaused = false;
+};
+
+extern CIdleSystem *g_pIdleSystem;

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -23,6 +23,7 @@
 #include "ctimer.h"
 #include "eventlistener.h"
 #include "entity/cgamerules.h"
+#include "idlemanager.h"
 #include "strtools.h"
 #include <stdio.h>
 #include "playermanager.h"
@@ -37,6 +38,7 @@ extern CCSGameRules* g_pGameRules;
 extern IVEngineServer2* g_pEngineServer2;
 extern CSteamGameServerAPIContext g_steamAPI;
 extern IGameTypes* g_pGameTypes;
+extern CIdleSystem* g_pIdleSystem;
 
 CMapVoteSystem* g_pMapVoteSystem = nullptr;
 
@@ -259,6 +261,8 @@ void CMapVoteSystem::OnLevelInit(const char* pMapName)
 void CMapVoteSystem::StartVote() 
 {
 	m_bIsVoteOngoing = true;
+
+	g_pIdleSystem->PauseIdleChecks();
 
 	// If we are forcing a map, just set all vote options to that map
 	if (m_iForcedNextMapIndex != -1) {

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -489,37 +489,6 @@ void ZEPlayer::EndGlow()
 		addresses::UTIL_Remove(pModelParent);
 }
 
-// Returns how long since a player has changed their inputs. Logged inputs and time for the logged
-// inputs are updated every time this function is run. Thus, when the logged input and the current
-// inputs are the same, the minimum return value is the time since the last time this function
-// was called
-uint64 ZEPlayer::GetIdleTime()
-{
-	CBasePlayerController* pTarget = (CBasePlayerController*)g_pEntitySystem->GetBaseEntity((CEntityIndex)(GetPlayerSlot().Get() + 1));
-	if (!pTarget)
-		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
-
-	const auto pPawn = pTarget->m_hPawn();
-	if (!pPawn)
-		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
-
-	const auto pMovement = pPawn->m_pMovementServices();
-	uint64 iCurrentMovement = IN_NONE;
-	if (pMovement)
-	{
-		const auto buttonStates = pMovement->m_nButtons().m_pButtonStates();
-		iCurrentMovement = buttonStates[0];
-	}
-	const auto buttonsChanged = m_iLastInputs ^ iCurrentMovement;
-
-	if (!buttonsChanged)
-		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
-
-	m_iLastInputs = iCurrentMovement;
-	m_iLastInputTime = std::time(0);
-	return 0;
-}
-
 void CPlayerManager::OnBotConnected(CPlayerSlot slot)
 {
 	m_vecPlayers[slot.Get()] = new ZEPlayer(slot, true);

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -489,6 +489,37 @@ void ZEPlayer::EndGlow()
 		addresses::UTIL_Remove(pModelParent);
 }
 
+// Returns how long since a player has changed their inputs. Logged inputs and time for the logged
+// inputs are updated every time this function is run. Thus, when the logged input and the current
+// inputs are the same, the minimum return value is the time since the last time this function
+// was called
+uint64 ZEPlayer::GetIdleTime()
+{
+	CBasePlayerController* pTarget = (CBasePlayerController*)g_pEntitySystem->GetBaseEntity((CEntityIndex)(GetPlayerSlot().Get() + 1));
+	if (!pTarget)
+		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
+
+	const auto pPawn = pTarget->m_hPawn();
+	if (!pPawn)
+		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
+
+	const auto pMovement = pPawn->m_pMovementServices();
+	uint64 iCurrentMovement = IN_NONE;
+	if (pMovement)
+	{
+		const auto buttonStates = pMovement->m_nButtons().m_pButtonStates();
+		iCurrentMovement = buttonStates[0];
+	}
+	const auto buttonsChanged = m_iLastInputs ^ iCurrentMovement;
+
+	if (!buttonsChanged)
+		return static_cast<uint64>(std::time(0) - m_iLastInputTime);
+
+	m_iLastInputs = iCurrentMovement;
+	m_iLastInputTime = std::time(0);
+	return 0;
+}
+
 void CPlayerManager::OnBotConnected(CPlayerSlot slot)
 {
 	m_vecPlayers[slot.Get()] = new ZEPlayer(slot, true);

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -171,7 +171,8 @@ public:
 	void SetLeaderVoteTime(float flCurtime) { m_flLeaderVoteTime = flCurtime; }
 	void SetGlowModel(CBaseModelEntity *pModel) { m_hGlowModel.Set(pModel); }
 	void SetSpeedMod(float flSpeedMod) { m_flSpeedMod = flSpeedMod; }
-	void ResetIdleTime() { m_iLastInputs = IN_NONE; m_iLastInputTime = std::time(0); }
+	void SetLastInputs(uint64 iLastInputs) { m_iLastInputs = iLastInputs; }
+	void UpdateLastInputTime() { m_iLastInputTime = std::time(0); }
 
 	bool IsMuted() { return m_bMuted; }
 	bool IsGagged() { return m_bGagged; }
@@ -202,7 +203,8 @@ public:
 	float GetLeaderVoteTime() { return m_flLeaderVoteTime; }
 	CBaseModelEntity *GetGlowModel() { return m_hGlowModel.Get(); }
 	float GetSpeedMod() { return m_flSpeedMod; }
-	uint64 GetIdleTime();
+	uint64 GetLastInputs() { return m_iLastInputs; }
+	std::time_t GetLastInputTime() { return m_iLastInputTime; }
 	
 	void OnSpawn();
 	void OnAuthenticated();

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -118,6 +118,8 @@ public:
 		m_iLeaderTracerIndex = 0;
 		m_flLeaderVoteTime = -30.0f;
 		m_flSpeedMod = 1.f;
+		m_iLastInputs = IN_NONE;
+		m_iLastInputTime = std::time(0);
 	}
 
 	~ZEPlayer()
@@ -169,6 +171,7 @@ public:
 	void SetLeaderVoteTime(float flCurtime) { m_flLeaderVoteTime = flCurtime; }
 	void SetGlowModel(CBaseModelEntity *pModel) { m_hGlowModel.Set(pModel); }
 	void SetSpeedMod(float flSpeedMod) { m_flSpeedMod = flSpeedMod; }
+	void ResetIdleTime() { m_iLastInputs = IN_NONE; m_iLastInputTime = std::time(0); }
 
 	bool IsMuted() { return m_bMuted; }
 	bool IsGagged() { return m_bGagged; }
@@ -199,6 +202,7 @@ public:
 	float GetLeaderVoteTime() { return m_flLeaderVoteTime; }
 	CBaseModelEntity *GetGlowModel() { return m_hGlowModel.Get(); }
 	float GetSpeedMod() { return m_flSpeedMod; }
+	uint64 GetIdleTime();
 	
 	void OnSpawn();
 	void OnAuthenticated();
@@ -249,6 +253,8 @@ private:
 	float m_flLeaderVoteTime;
 	CHandle<CBaseModelEntity> m_hGlowModel;
 	float m_flSpeedMod;
+	uint64 m_iLastInputs;
+	std::time_t m_iLastInputTime;
 };
 
 class CPlayerManager


### PR DESCRIPTION
'Convars':
`cs2f_idle_kick_time <float>` - Amount of minutes before kicking idle players. 0 to disable afk kicking.
`cs2f_idle_kick_min_players <int>` - Minimum amount of connected clients to kick idle players.
`cs2f_idle_kick_admins <bool>` - Whether to kick idle players with ADMFLAG_GENERIC