### PR TITLE
[Z:R] Implement Hitgroup Knockback for more handle aside Weapon Knockback.

### DIFF
--- a/PackageScript
+++ b/PackageScript
@@ -62,6 +62,7 @@ builder.AddCopy(os.path.join(builder.sourcePath, 'cfg', MMSPlugin.plugin_name, '
 builder.AddCopy(os.path.join(builder.sourcePath, 'cfg', MMSPlugin.plugin_name, 'maps', 'de_somemap.cfg'), mapcfg_folder)
 builder.AddCopy(os.path.join(builder.sourcePath, 'configs', 'zr', 'playerclass.jsonc.example'), zr_folder)
 builder.AddCopy(os.path.join(builder.sourcePath, 'configs', 'zr', 'weapons.cfg.example'), zr_folder)
+builder.AddCopy(os.path.join(builder.sourcePath, 'configs', 'zr', 'hitgroups.cfg.example'), zr_folder)
 builder.AddCopy(os.path.join('gamedata', 'cs2fixes.games.txt'), gamedata_folder)
 
 # Add CS2Fixes-specific compiled asset files

--- a/configs/zr/hitgroups.cfg.example
+++ b/configs/zr/hitgroups.cfg.example
@@ -1,0 +1,130 @@
+// SHORT DESCRIPTIONS
+//
+// Attribute:               Values:     Description:
+// ----------------------------------------------------------------------------
+// index                    number      The hitgroup index.
+// enabled                  1/0     	If enabled. The knockback will apply multiplier from knockback config.
+// knockback                decimal     The knockback multiplier for this hitgroup.
+
+"Hitgroups"
+{
+	"Generic"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"0"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"Head"
+	{
+		// enabled
+		"enabled"	"1"
+
+		// General
+		"index"		"1"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"Chest"
+	{
+		// enabled
+		"enabled"	"1"
+
+		// General
+		"index"		"2"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"Stomach"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"3"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"LeftArm"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"4"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"RightArm"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"5"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"LeftLeg"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"6"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"RightLeg"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"7"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+
+	"Neck"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"8"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+	
+	"Gear"
+	{
+		// enabled
+		"enabled"	"1"
+		
+		// General
+		"index"		"10"
+
+		// Knockback
+		"knockback"	"1.0"
+	}
+}

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -286,6 +286,7 @@ bool CS2Fixes::Load(PluginId id, ISmmAPI *ismm, char *error, size_t maxlen, bool
 	g_pUserPreferencesSystem = new CUserPreferencesSystem();
 	g_pUserPreferencesStorage = new CUserPreferencesREST();
 	g_pZRWeaponConfig = new ZRWeaponConfig();
+	g_pZRHitgroupConfig = new ZRHitgroupConfig();
 	g_pEntityListener = new CEntityListener();
 
 	RegisterWeaponCommands();
@@ -360,6 +361,9 @@ bool CS2Fixes::Unload(char *error, size_t maxlen)
 
 	if (g_pZRWeaponConfig)
 		delete g_pZRWeaponConfig;
+	
+	if (g_pZRHitgroupConfig)
+		delete g_pZRHitgroupConfig;
 
 	if (g_pUserPreferencesSystem)
 		delete g_pUserPreferencesSystem;

--- a/src/zombiereborn.h
+++ b/src/zombiereborn.h
@@ -243,7 +243,6 @@ struct ZRWeapon
 
 struct ZRHitgroup
 {
-	//const char *sIndex;
 	float flKnockback;
 };
 
@@ -269,7 +268,7 @@ public:
 		m_HitgroupMap.SetLessFunc(DefLessFunc(uint32));
 	};
 	void LoadHitgroupConfig();
-	ZRHitgroup* FindHitgroupIndex(const char *pszHitgroupname);
+	ZRHitgroup* FindHitgroupIndex(int iIndex);
 private:
 	CUtlMap<uint32, ZRHitgroup*> m_HitgroupMap;
 };

--- a/src/zombiereborn.h
+++ b/src/zombiereborn.h
@@ -241,6 +241,12 @@ struct ZRWeapon
 	float flKnockback;
 };
 
+struct ZRHitgroup
+{
+	//const char *sIndex;
+	float flKnockback;
+};
+
 class ZRWeaponConfig
 {
 public:
@@ -254,7 +260,22 @@ private:
 	CUtlMap<uint32, ZRWeapon*> m_WeaponMap;
 };
 
+
+class ZRHitgroupConfig
+{
+public:
+	ZRHitgroupConfig()
+	{
+		m_HitgroupMap.SetLessFunc(DefLessFunc(uint32));
+	};
+	void LoadHitgroupConfig();
+	ZRHitgroup* FindHitgroupIndex(const char *pszHitgroupname);
+private:
+	CUtlMap<uint32, ZRHitgroup*> m_HitgroupMap;
+};
+
 extern ZRWeaponConfig *g_pZRWeaponConfig;
+extern ZRHitgroupConfig *g_pZRHitgroupConfig;
 extern CZRPlayerClassManager* g_pZRPlayerClassManager;
 
 extern bool g_bEnableZR;


### PR DESCRIPTION
- Update weapons knockback config to use up to 2 decimals (from `0.0f` to `.2f`).
- Add hitgroups feature like in old Zombie:Reloaded for more control in handling knockback. (Tested offline with bots and worked fine. Need test on full server).
