### PR TITLE
Add panorama vote support

### DIFF
--- a/AMBuilder
+++ b/AMBuilder
@@ -65,6 +65,7 @@ for sdk_target in MMSPlugin.sdk_targets:
     'src/utils/entity.cpp',
     'src/cs2_sdk/schema.cpp',
     'src/ctimer.cpp',
+    'src/panoramavote.cpp',
     'src/playermanager.cpp',
     'src/gameconfig.cpp',
     'src/gamesystem.cpp',

--- a/CS2Fixes.vcxproj
+++ b/CS2Fixes.vcxproj
@@ -195,6 +195,7 @@
     <ClCompile Include="src\idlemanager.cpp" />
     <ClCompile Include="src\map_votes.cpp" />
     <ClCompile Include="src\mempatch.cpp" />
+    <ClCompile Include="src\panoramavote.cpp" />
     <ClCompile Include="src\patches.cpp" />
     <ClCompile Include="src\playermanager.cpp" />
     <ClCompile Include="src\user_preferences.cpp" />
@@ -231,6 +232,7 @@
     <ClInclude Include="src\cs2_sdk\entity\ctakedamageinfo.h" />
     <ClInclude Include="src\cs2_sdk\entity\cteam.h" />
     <ClInclude Include="src\cs2_sdk\entity\ctriggerpush.h" />
+    <ClInclude Include="src\cs2_sdk\entity\cvotecontroller.h" />
     <ClInclude Include="src\cs2_sdk\entity\globaltypes.h" />
     <ClInclude Include="src\cs2_sdk\entity\lights.h" />
     <ClInclude Include="src\cs2_sdk\entity\services.h" />
@@ -248,6 +250,7 @@
     <ClInclude Include="src\idlemanager.h" />
     <ClInclude Include="src\mempatch.h" />
     <ClInclude Include="src\addresses.h" />
+    <ClInclude Include="src\panoramavote.h" />
     <ClInclude Include="src\patches.h" />
     <ClInclude Include="src\playermanager.h" />
     <ClInclude Include="src\recipientfilters.h" />

--- a/CS2Fixes.vcxproj.filters
+++ b/CS2Fixes.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClCompile Include="src\entities.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\panoramavote.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\mempatch.h">
@@ -311,6 +314,12 @@
       <Filter>Header Files\cs2_sdk\entity</Filter>
     </ClInclude>
     <ClInclude Include="src\cs2_sdk\entity\clogiccase.h">
+      <Filter>Header Files\cs2_sdk\entity</Filter>
+    </ClInclude>
+    <ClInclude Include="src\panoramavote.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\cs2_sdk\entity\cvotecontroller.h">
       <Filter>Header Files\cs2_sdk\entity</Filter>
     </ClInclude>
   </ItemGroup>

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -51,14 +51,24 @@ cs2f_flood_interval 			0.75	// Amount of time allowed between chat messages acqu
 cs2f_max_flood_tokens 			3		// Maximum number of flood tokens allowed before chat messages are blocked
 cs2f_flood_cooldown 			3.0		// Amount of time to block messages for when a player floods
 
-// Vote settings
-cs2f_extends 					1		// Maximum extends per map
-cs2f_extend_success_ratio 		0.5		// Ratio needed to pass an extend
-cs2f_extend_time 				20		// Time to add per extend
-cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
-cs2f_rtv_endround				0		// Whether to immediately end the round when RTV succeeds
-cs2f_vote_maps_cooldown			10		// Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
-cs2f_vote_max_nominations		10		// Number of nominations to include per vote, out of a maximum of 10.
+// Extend vote settings
+cs2f_extend_mode                3       // How extend votes are handled. [0=off, 1=only admins can start, 2=players can start with !ve, 3=auto start at given timeleft]
+cs2f_extend_vote_delay          120.0   // If cs2f_extend_mode is 2, Time after map start until extend votes can be triggered
+cs2f_extends                    1       // Maximum extends per map
+cs2f_extend_success_ratio       0.5     // Ratio needed to pass an extend
+cs2f_extend_time                20      // Time to add per extend (minutes)
+cs2f_extend_vote_start_time     1.0     // If cs2f_extend_mode is 3, start an extend vote at this timeleft (minutes)
+cs2f_extend_vote_duration       30.0    // Time to leave the extend vote active for (seconds)
+cs2f_extend_begin_ratio         0.4     // If cs2f_extend_mode is 2, Ratio needed to begin an extend vote
+
+// RTV settings
+cs2f_rtv_vote_delay             120.0   // Time after map start until RTV votes can be cast
+cs2f_rtv_success_ratio          0.6     // Ratio needed to pass RTV
+cs2f_rtv_endround               0       // Whether to immediately end the round when RTV succeeds
+
+// Map vote settings
+cs2f_vote_maps_cooldown         10      // Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
+cs2f_vote_max_nominations       10      // Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings
 cs2f_user_prefs_api				""		// User Preferences REST API endpoint

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -52,23 +52,23 @@ cs2f_max_flood_tokens 			3		// Maximum number of flood tokens allowed before cha
 cs2f_flood_cooldown 			3.0		// Amount of time to block messages for when a player floods
 
 // Extend vote settings
-cs2f_extend_mode                3       // How extend votes are handled. [0=off, 1=only admins can start, 2=players can start with !ve, 3=auto start at given timeleft]
-cs2f_extend_vote_delay          120.0   // If cs2f_extend_mode is 2, Time after map start until extend votes can be triggered
-cs2f_extends                    1       // Maximum extends per map
-cs2f_extend_success_ratio       0.5     // Ratio needed to pass an extend
-cs2f_extend_time                20      // Time to add per extend (minutes)
-cs2f_extend_vote_start_time     1.0     // If cs2f_extend_mode is 3, start an extend vote at this timeleft (minutes)
-cs2f_extend_vote_duration       30.0    // Time to leave the extend vote active for (seconds)
-cs2f_extend_begin_ratio         0.4     // If cs2f_extend_mode is 2, Ratio needed to begin an extend vote
+cs2f_extend_mode 				3		// How extend votes are handled. [0=off, 1=only admins can start, 2=players can start with !ve, 3=auto start at given timeleft]
+cs2f_extend_vote_delay 			120.0	// If cs2f_extend_mode is 2, Time after map start until extend votes can be triggered
+cs2f_extends 					1		// Maximum extends per map
+cs2f_extend_success_ratio 		0.5		// Ratio needed to pass an extend
+cs2f_extend_time 				20		// Time to add per extend (minutes)
+cs2f_extend_vote_start_time 	1.0		// If cs2f_extend_mode is 3, start an extend vote at this timeleft (minutes)
+cs2f_extend_vote_duration 		30.0	// Time to leave the extend vote active for (seconds)
+cs2f_extend_begin_ratio 		0.4		// If cs2f_extend_mode is 2, Ratio needed to begin an extend vote
 
 // RTV settings
-cs2f_rtv_vote_delay             120.0   // Time after map start until RTV votes can be cast
-cs2f_rtv_success_ratio          0.6     // Ratio needed to pass RTV
-cs2f_rtv_endround               0       // Whether to immediately end the round when RTV succeeds
+cs2f_rtv_vote_delay 			120.0	// Time after map start until RTV votes can be cast
+cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
+cs2f_rtv_endround 				0		// Whether to immediately end the round when RTV succeeds
 
 // Map vote settings
-cs2f_vote_maps_cooldown         10      // Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
-cs2f_vote_max_nominations       10      // Number of nominations to include per vote, out of a maximum of 10.
+cs2f_vote_maps_cooldown 		10		// Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
+cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings
 cs2f_user_prefs_api				""		// User Preferences REST API endpoint

--- a/src/cs2_sdk/entity/cvotecontroller.h
+++ b/src/cs2_sdk/entity/cvotecontroller.h
@@ -1,0 +1,38 @@
+/**
+ * =============================================================================
+ * CS2Fixes
+ * Copyright (C) 2023-2024 Source2ZE
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cbaseentity.h"
+//#include "util_shared.h"
+
+class CVoteController : public CBaseEntity
+{
+public:
+	DECLARE_SCHEMA_CLASS(CVoteController);
+
+	SCHEMA_FIELD(int, m_iActiveIssueIndex)
+		SCHEMA_FIELD(int, m_iOnlyTeamToVote)
+		SCHEMA_FIELD_POINTER(int, m_nVoteOptionCount)
+		SCHEMA_FIELD(int, m_nPotentialVotes)
+		SCHEMA_FIELD(bool, m_bIsYesNoVote)
+		SCHEMA_FIELD_POINTER(int, m_nVotesCast)
+		SCHEMA_FIELD(int, m_nHighestCountIndex)
+		SCHEMA_FIELD_POINTER(CUtlVector<const char* >, m_VoteOptions)
+};

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -29,6 +29,7 @@
 #include "votemanager.h"
 #include "leader.h"
 #include "recipientfilters.h"
+#include "panoramavote.h"
 
 #include "tier0/memdbgon.h"
 
@@ -213,6 +214,8 @@ FAKE_BOOL_CVAR(cs2f_full_alltalk, "Whether to enforce sv_full_alltalk 1", g_bFul
 
 GAME_EVENT_F(round_start)
 {
+	g_pPanoramaVoteHandler->Init();
+
 	if (g_bEnableZR)
 		ZR_OnRoundStart(pEvent);
 
@@ -323,4 +326,9 @@ GAME_EVENT_F(bullet_impact)
 {
 	if (g_bEnableLeader)
 		Leader_BulletImpact(pEvent);
+}
+
+GAME_EVENT_F(vote_cast)
+{
+	g_pPanoramaVoteHandler->VoteCast(pEvent);
 }

--- a/src/panoramavote.cpp
+++ b/src/panoramavote.cpp
@@ -1,0 +1,422 @@
+/**
+ * =============================================================================
+ * CS2Fixes
+ * Copyright (C) 2023-2024 Source2ZE
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cstrike15_usermessages.pb.h"
+
+#include "utlstring.h"
+#include "common.h"
+#include "cs2fixes.h"
+#include "panoramavote.h"
+#include "commands.h"
+#include "engine/igameeventsystem.h"
+#include "networksystem/inetworkmessages.h"
+#include "recipientfilters.h"
+#include "utils/entity.h"
+#include "entity/cvotecontroller.h"
+#include "ctimer.h"
+
+extern IGameEventManager2* g_gameEventManager;
+extern IGameEventSystem *g_gameEventSystem;
+extern INetworkMessages *g_pNetworkMessages;
+
+CPanoramaVoteHandler* g_pPanoramaVoteHandler = nullptr;
+
+void CPanoramaVoteHandler::Reset()
+{
+	m_bIsVoteInProgress = false;
+	hVoteController = nullptr;
+	m_VoteHandler = nullptr;
+	m_VoteResult = nullptr;
+	m_szCurrentVoteTitle[0] = '\0';
+	m_szCurrentVoteDetailStr[0] = '\0';
+}
+
+void CPanoramaVoteHandler::Init()
+{
+	if (m_bIsVoteInProgress)
+		return;
+
+	CVoteController* pVoteController = nullptr;
+	while (nullptr != (pVoteController = (CVoteController*)UTIL_FindEntityByClassname(pVoteController, "vote_controller")))
+	{
+		hVoteController = pVoteController->GetHandle();
+	}
+}
+
+// Called by vote_cast event
+void CPanoramaVoteHandler::VoteCast(IGameEvent* pEvent)
+{
+	if (!hVoteController.Get() || !m_bIsVoteInProgress)
+		return;
+
+	if (m_VoteHandler != nullptr)
+	{
+		CCSPlayerController* pVoter = (CCSPlayerController*)pEvent->GetPlayerController("userid");
+		if (!pVoter) return;
+		(m_VoteHandler)(YesNoVoteAction::VoteAction_Vote, pVoter->GetPlayerSlot(), pEvent->GetInt("vote_option"));
+	}
+
+	CheckForEarlyVoteClose();
+	
+	//ClientPrintAll(HUD_PRINTTALK, "VOTE CAST: slot:%d option:%d", pVoter->GetPlayerSlot(), pEvent->GetInt("vote_option"));
+}
+
+void CPanoramaVoteHandler::RemovePlayerFromVote(int iSlot)
+{
+	if (!m_bIsVoteInProgress)
+		return;
+
+	bool found = false;
+	for (int i = 0; i < m_iVoterCount; i++)
+	{
+		if (m_iVoters[i] == iSlot)
+		{
+			found = true;
+		}
+		else if (found)
+		{
+			m_iVoters[i - 1] = m_iVoters[i];
+		}
+	}
+
+	if (found)
+	{
+		m_iVoterCount--;
+		m_iVoters[m_iVoterCount] = -1;
+	}
+}
+
+bool CPanoramaVoteHandler::IsPlayerInVotePool(int iSlot)
+{
+	if (!m_bIsVoteInProgress)
+		return false;
+
+	if (iSlot < 0 || iSlot > MAXPLAYERS)
+		return false;
+
+	for (int i = 0; i < m_iVoterCount; i++)
+	{
+		if (m_iVoters[i] == iSlot)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+// Removes a client's vote and redraws the vote
+bool CPanoramaVoteHandler::RedrawVoteToClient(int iSlot)
+{
+	if (!hVoteController.Get())
+		return false;
+
+	int myVote = hVoteController->m_nVotesCast[iSlot];
+	if (myVote != VOTE_UNCAST)
+	{
+		hVoteController->m_nVotesCast[iSlot] = VOTE_UNCAST;
+		hVoteController->m_nVoteOptionCount[myVote]--;
+
+		UpdateVoteCounts();
+	}
+
+	CRecipientFilter pFilter;
+	pFilter.AddRecipient(CPlayerSlot(iSlot));
+	SendVoteStartUM(&pFilter);
+	
+	return true;
+}
+
+void CPanoramaVoteHandler::UpdateVoteCounts()
+{
+	IGameEvent* pEvent = g_gameEventManager->CreateEvent("vote_changed");
+
+	if (pEvent)
+	{
+		pEvent->SetInt("vote_option1", hVoteController->m_nVoteOptionCount[0]);
+		pEvent->SetInt("vote_option2", hVoteController->m_nVoteOptionCount[1]);
+		pEvent->SetInt("vote_option3", hVoteController->m_nVoteOptionCount[2]);
+		pEvent->SetInt("vote_option4", hVoteController->m_nVoteOptionCount[3]);
+		pEvent->SetInt("vote_option5", hVoteController->m_nVoteOptionCount[4]);
+		pEvent->SetInt("potentialVotes", m_iVoterCount);
+
+		g_gameEventManager->FireEvent(pEvent, false);
+	}
+}
+
+bool CPanoramaVoteHandler::IsVoteInProgress()
+{
+	return m_bIsVoteInProgress;
+}
+
+bool CPanoramaVoteHandler::SendYesNoVote(float flDuration, int iCaller, const char* sVoteTitle, const char* sDetailStr, IRecipientFilter *pFilter, YesNoVoteResult resultCallback, YesNoVoteHandler handler = nullptr)
+{
+	if (!hVoteController.Get() || m_bIsVoteInProgress)
+		return false;
+
+	if (pFilter->GetRecipientCount() <= 0)
+		return false;
+
+	if (resultCallback == nullptr)
+		return false;
+
+	Message("[Vote Start] Starting a new vote [id:%d]. Duration:%.1f Caller:%d NumClients:%d", m_iVoteCount, flDuration, iCaller, pFilter->GetRecipientCount());
+
+	m_bIsVoteInProgress = true;
+
+	InitVoters(pFilter);
+
+	hVoteController->m_nPotentialVotes = m_iVoterCount;
+	hVoteController->m_bIsYesNoVote = true;
+	hVoteController->m_iActiveIssueIndex = 2;
+
+	hVoteController->m_iOnlyTeamToVote = -1; // use the recipient filter param to handle who votes
+	
+	m_VoteResult = resultCallback;
+	m_VoteHandler = handler;
+
+	m_iCurrentVoteCaller = iCaller;
+	V_strcpy(m_szCurrentVoteTitle, sVoteTitle);
+	V_strcpy(m_szCurrentVoteDetailStr, sDetailStr);
+
+	UpdateVoteCounts();
+
+	SendVoteStartUM(pFilter);
+
+	if (m_VoteHandler != nullptr)
+	{
+		(m_VoteHandler)(YesNoVoteAction::VoteAction_Start, 0, 0);
+	}
+	
+	int voteNum = m_iVoteCount;
+	new CTimer(flDuration, false, true, [voteNum]() 
+		{
+			// Ensure we dont end the wrong vote
+			if(voteNum == g_pPanoramaVoteHandler->m_iVoteCount)
+				g_pPanoramaVoteHandler->EndVote(YesNoVoteEndReason::VoteEnd_TimeUp);
+			return -1.0;
+		}
+	);
+	
+	return true;
+}
+
+bool CPanoramaVoteHandler::SendYesNoVoteToAll(float flDuration, int iCaller, const char* sVoteTitle, const char* sDetailStr, YesNoVoteResult resultCallback, YesNoVoteHandler handler = nullptr)
+{
+	CRecipientFilter filter;
+	filter.AddAllPlayers();
+
+	return SendYesNoVote(flDuration, iCaller, sVoteTitle, sDetailStr, &filter, resultCallback, handler);
+}
+
+void CPanoramaVoteHandler::SendVoteStartUM(IRecipientFilter *pFilter)
+{
+	INetworkSerializable* pNetmsg = g_pNetworkMessages->FindNetworkMessagePartial("VoteStart");
+
+	CCSUsrMsg_VoteStart data;
+	data.set_team(-1);
+	data.set_player_slot(m_iCurrentVoteCaller);
+	data.set_vote_type(-1);
+	data.set_disp_str(m_szCurrentVoteTitle);
+	data.set_details_str(m_szCurrentVoteDetailStr);
+	data.set_is_yes_no_vote(true);
+
+	g_gameEventSystem->PostEventAbstract(-1, false, pFilter, pNetmsg, &data, 0);
+}
+
+void CPanoramaVoteHandler::InitVoters(IRecipientFilter *pFilter)
+{
+	// Clear any old info
+	m_iVoterCount = 0;
+	for (int i = 0; i < MAXPLAYERS; i++)
+	{
+		m_iVoters[i] = -1;
+		hVoteController->m_nVotesCast[i] = VOTE_UNCAST;
+	}
+
+	for (int i = 0; i < VOTE_UNCAST; i++)
+		hVoteController->m_nVoteOptionCount[i] = 0;
+	
+	m_iVoterCount = pFilter->GetRecipientCount();
+	for (int i = 0, j = 0; i < m_iVoterCount; i++)
+	{
+		CPlayerSlot slot = pFilter->GetRecipientIndex(i);
+		if (slot.Get() != -1)
+		{
+			m_iVoters[j] = slot.Get();
+			j++;
+		}
+	}
+}
+
+void CPanoramaVoteHandler::CheckForEarlyVoteClose()
+{
+	int votes = 0;
+	votes += hVoteController->m_nVoteOptionCount[VOTE_OPTION1];
+	votes += hVoteController->m_nVoteOptionCount[VOTE_OPTION2];
+
+	if (votes >= m_iVoterCount)
+	{
+		// Do this next frame to prevent a crash
+		new CTimer(0.0, false, true, []() 
+			{
+				g_pPanoramaVoteHandler->EndVote(YesNoVoteEndReason::VoteEnd_AllVotes);
+				return -1.0;
+			}
+		);
+	}
+}
+
+void CPanoramaVoteHandler::EndVote(YesNoVoteEndReason reason)
+{
+	if (!m_bIsVoteInProgress)
+		return;
+
+	m_bIsVoteInProgress = false;
+
+	switch (reason)
+	{
+	case VoteEnd_AllVotes:
+		Message("[Vote Ending] [id:%d] All possible players voted.", m_iVoteCount);
+		break;
+	case VoteEnd_TimeUp:
+		Message("[Vote Ending] [id:%d] Time ran out.", m_iVoteCount);
+		break;
+	case VoteEnd_Cancelled:
+		Message("[Vote Ending] [id:%d] The vote has been cancelled.", m_iVoteCount);
+		break;
+	}
+
+	// Cycle global vote counter
+	if (m_iVoteCount == 99) m_iVoteCount = 0;
+	else m_iVoteCount++;
+		
+	if (m_VoteHandler != nullptr)
+	{
+		(m_VoteHandler)(YesNoVoteAction::VoteAction_End, reason, 0);
+	}
+
+	if (!hVoteController.Get())
+	{
+		SendVoteFailed();
+		return;
+	}
+
+	if (m_VoteResult == nullptr || reason == YesNoVoteEndReason::VoteEnd_Cancelled)
+	{
+		SendVoteFailed();
+		hVoteController->m_iActiveIssueIndex = -1;
+		return;
+	}
+
+	YesNoVoteInfo info{};
+	info.num_clients = m_iVoterCount;
+	info.yes_votes = hVoteController->m_nVoteOptionCount[VOTE_OPTION1];
+	info.no_votes = hVoteController->m_nVoteOptionCount[VOTE_OPTION2];
+	info.num_votes = info.yes_votes + info.no_votes;
+	
+	for (int i = 0; i < MAXPLAYERS; i++)
+	{
+		if (i < m_iVoterCount)
+		{
+			info.clientInfo[i][VOTEINFO_CLIENT_SLOT] = m_iVoters[i];
+			info.clientInfo[i][VOTEINFO_CLIENT_ITEM] = hVoteController->m_nVotesCast[m_iVoters[i]];
+		}
+		else
+		{
+			info.clientInfo[i][VOTEINFO_CLIENT_SLOT] = -1;
+			info.clientInfo[i][VOTEINFO_CLIENT_ITEM] = -1;
+		}
+	}
+
+	bool passed = (m_VoteResult)(info);
+	//TODO usermessage correctly
+	if (passed)
+	{
+		SendVotePassed();
+	}
+	else
+	{
+		SendVoteFailed();
+	}
+}
+
+void CPanoramaVoteHandler::SendVoteFailed()
+{
+	INetworkSerializable* pNetmsg = g_pNetworkMessages->FindNetworkMessagePartial("VoteFailed");
+
+	CCSUsrMsg_VoteFailed data;
+	data.set_reason(0);
+	data.set_team(-1);
+
+	CRecipientFilter pFilter;
+	pFilter.AddAllPlayers();
+	g_gameEventSystem->PostEventAbstract(-1, false, &pFilter, pNetmsg, &data, 0);
+}
+
+void CPanoramaVoteHandler::SendVotePassed()
+{
+	INetworkSerializable* pNetmsg = g_pNetworkMessages->FindNetworkMessagePartial("VotePass");
+
+	CCSUsrMsg_VotePass data;
+	data.set_team(-1);
+	data.set_vote_type(2);
+	data.set_disp_str("#SFUI_Vote_None");
+	data.set_details_str("");
+
+	CRecipientFilter pFilter;
+	pFilter.AddAllPlayers();
+	g_gameEventSystem->PostEventAbstract(-1, false, &pFilter, pNetmsg, &data, 0);
+}
+
+CON_COMMAND_CHAT_FLAGS(cancelvote, "Cancels the ongoing vote.", ADMFLAG_CHANGEMAP)
+{
+	if (!g_pPanoramaVoteHandler)
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Votes cannot be started/stopped at the moment.");
+		return;
+	}
+
+	if (!g_pPanoramaVoteHandler->IsVoteInProgress())
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "No vote in progress.");
+		return;
+	}
+
+	g_pPanoramaVoteHandler->EndVote(YesNoVoteEndReason::VoteEnd_Cancelled);
+
+	const char* pszCommandPlayerName = player ? player->GetPlayerName() : "Console";
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Admin %s has cancelled the vote.", pszCommandPlayerName);
+}
+
+CON_COMMAND_CHAT(revote, "Change your vote in the ongoing vote.")
+{
+	if (!g_pPanoramaVoteHandler->IsVoteInProgress())
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "No vote in progress.");
+		return;
+	}
+
+	int slot = player->GetPlayerSlot();
+	if (!g_pPanoramaVoteHandler->RedrawVoteToClient(slot))
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "No vote in progress.");
+		return;
+	}
+}

--- a/src/panoramavote.h
+++ b/src/panoramavote.h
@@ -1,0 +1,150 @@
+/**
+ * =============================================================================
+ * CS2Fixes
+ * Copyright (C) 2023-2024 Source2ZE
+ * =============================================================================
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, version 3.0, as published by the
+ * Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "common.h"
+#include "eventlistener.h"
+#include "irecipientfilter.h"
+#include "utils/entity.h"
+#include "entity/cvotecontroller.h"
+
+#define VOTE_CALLER_SERVER 99
+
+enum CastVote
+{
+	VOTE_NOTINCLUDED = -1,
+	VOTE_OPTION1,  // Use this for Yes
+	VOTE_OPTION2,  // Use this for No
+	VOTE_OPTION3,
+	VOTE_OPTION4,
+	VOTE_OPTION5,
+	VOTE_UNCAST = 5
+};
+
+enum YesNoVoteEndReason
+{
+	VoteEnd_AllVotes,	// All possible votes were cast
+	VoteEnd_TimeUp,		// Time ran out
+	VoteEnd_Cancelled,	// The vote got cancelled
+};
+
+enum YesNoVoteAction
+{
+	VoteAction_Start, // nothing passed
+	VoteAction_Vote,  // param1 = client slot, param2 = choice (VOTE_OPTION1=yes, VOTE_OPTION2=no)
+	VoteAction_End,   // param1 = YesNoVoteEndReason reason why the vote ended
+};
+
+#define VOTEINFO_CLIENT_SLOT 0
+#define VOTEINFO_CLIENT_ITEM 1
+struct YesNoVoteInfo
+{
+	int num_votes;					// Number of votes tallied in total
+	int yes_votes;					// Number of votes for yes
+	int no_votes;					// Number of votes for no
+	int num_clients;				// Number of clients who could vote
+	int clientInfo[MAXPLAYERS][2];	// Client voting info, user VOTEINFO_CLIENT_ defines
+									//     Anything >= [num_clients] is VOTE_NOTINCLUDED, VOTE_UNCAST = client didn't vote
+};
+
+// Used to handle events relating to the vote menu
+#define YesNoVoteHandler std::function<void(YesNoVoteAction, int, int)>
+
+// Sends the vote results when the vote ends
+// Return true for vote to pass, false to fail
+#define YesNoVoteResult std::function<bool(YesNoVoteInfo)>
+
+class CPanoramaVoteHandler
+{
+public:
+	CPanoramaVoteHandler()
+	{
+		m_iVoteCount = 0;
+		m_bIsVoteInProgress = false;
+		m_VoteHandler = nullptr;
+		m_VoteResult = nullptr;
+	}
+	int m_iVoteCount;
+
+	void Reset();
+	void Init();
+	void VoteCast(IGameEvent* pEvent);
+
+	void RemovePlayerFromVote(int iSlot);
+
+	bool IsPlayerInVotePool(int iSlot);
+
+	bool HasPlayerVoted(int iSlot);
+
+	// Removes a client's vote and redraws the vote
+	// True if client was in the vote, false if no ongoing vote
+	bool RedrawVoteToClient(int iSlot);
+	
+	/* Returns true if a vote is in progress, false otherwise */
+	bool IsVoteInProgress();
+	
+	// Ends the ongoing vote with the specified reason
+	void EndVote(YesNoVoteEndReason reason);
+
+	/* Start a new Yes/No vote
+	*  
+	*  @param flDuration		Maximum time to leave vote active for
+	*  @param iCaller			Player slot of the vote caller. Use VOTE_CALLER_SERVER for 'Server'.
+	*  @param sVoteTitle		Translation string to use as the vote message. (Only '#SFUI_vote' or '#Panorama_vote' strings)
+	*  @param sDetailStr		Extra string used in some vote translation strings.
+	*  @param pFilter			Recipient filter with all the clients who are allowed to participate in the vote.
+	*  @param handler			Called when a menu action is completed.
+	*  @param callback			Called when the vote has finished.
+	*/
+	bool SendYesNoVote(float flDuration, int iCaller, const char* sVoteTitle, const char* sDetailStr, IRecipientFilter *pFilter, YesNoVoteResult resultCallback, YesNoVoteHandler handler);
+
+	/* Start a new Yes/No vote with all players included
+	*
+	*  @param flDuration		Maximum time to leave vote active for
+	*  @param iCaller			Player slot of the vote caller. Use VOTE_CALLER_SERVER for 'Server'.
+	*  @param sVoteTitle		Translation string to use as the vote message. (Only '#SFUI_vote' or '#Panorama_vote' strings)
+	*  @param sDetailStr		Extra string used in some vote translation strings.
+	*  @param handler			Called when a menu action is completed.
+	*  @param callback			Called when the vote has finished.
+	*/
+	bool SendYesNoVoteToAll(float flDuration, int iCaller, const char* sVoteTitle, const char* sDetailStr, YesNoVoteResult resultCallback, YesNoVoteHandler handler);
+
+	void SendVoteFailed();
+	void SendVotePassed();
+
+private:
+	CHandle<CVoteController> hVoteController;
+	bool m_bIsVoteInProgress;
+	YesNoVoteHandler m_VoteHandler;
+	YesNoVoteResult m_VoteResult;
+	int m_iVoterCount;
+	int m_iVoters[MAXPLAYERS];
+
+	int m_iCurrentVoteCaller;
+	char m_szCurrentVoteTitle[256];
+	char m_szCurrentVoteDetailStr[256];
+
+	void CheckForEarlyVoteClose();
+	void InitVoters(IRecipientFilter* pFilter);
+	void SendVoteStartUM(IRecipientFilter* pFilter);
+	void UpdateVoteCounts();
+};
+
+extern CPanoramaVoteHandler *g_pPanoramaVoteHandler;

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -24,6 +24,7 @@
 #include "commands.h"
 #include "map_votes.h"
 #include "user_preferences.h"
+#include "panoramavote.h"
 #include "entity/ccsplayercontroller.h"
 #include "utils/entity.h"
 #include "serversideclient.h"
@@ -547,6 +548,8 @@ void CPlayerManager::OnClientDisconnect(CPlayerSlot slot)
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
+
+	g_pPanoramaVoteHandler->RemovePlayerFromVote(slot.Get());
 }
 
 void CPlayerManager::OnClientPutInServer(CPlayerSlot slot)

--- a/src/votemanager.cpp
+++ b/src/votemanager.cpp
@@ -23,13 +23,14 @@
 #include "ctimer.h"
 #include "icvar.h"
 #include "entity/cgamerules.h"
+#include "panoramavote.h"
 
 #include "tier0/memdbgon.h"
 
-extern CGameEntitySystem *g_pEntitySystem;
-extern IVEngineServer2 *g_pEngineServer2;
-extern CGlobalVars *gpGlobals;
-extern CCSGameRules *g_pGameRules;
+extern CGameEntitySystem* g_pEntitySystem;
+extern IVEngineServer2* g_pEngineServer2;
+extern CGlobalVars* gpGlobals;
+extern CCSGameRules* g_pGameRules;
 
 ERTVState g_RTVState = ERTVState::MAP_START;
 EExtendState g_ExtendState = EExtendState::MAP_START;
@@ -41,12 +42,110 @@ int g_iExtendTimeToAdd = 20;
 float g_flRTVSucceedRatio = 0.6f;
 bool g_bRTVEndRound = false;
 
+int g_ExtendVoteMode = (int)EExtendVoteMode::EXTENDVOTE_ADMINONLY;
+float g_flExtendVoteStartTime = 4.0f;
+float g_flExtendVoteDuration = 30.0f;
+float g_flExtendBeginRatio = 0.4f;
+
+float g_flExtendVoteDelay = 300.0f;
+float g_flRtvDelay = 300.0f;
+
 FAKE_BOOL_CVAR(cs2f_votemanager_enable, "Whether to enable votemanager features such as RTV and extends", g_bVoteManagerEnable, false, false)
+FAKE_FLOAT_CVAR(cs2f_extend_vote_delay, "If cs2f_extend_mode is 2, Time after map start until extend votes can be triggered", g_flExtendVoteDelay, 120.0f, false)
+FAKE_INT_CVAR(cs2f_extend_mode, "How extend votes are handled. (0=off, 1=only admins can start, 2=players can start with !ve, 3=auto start at given timeleft)", g_ExtendVoteMode, (int)EExtendVoteMode::EXTENDVOTE_ADMINONLY, false)
 FAKE_INT_CVAR(cs2f_extends, "Maximum extends per map", g_iExtendsLeft, 1, false)
-FAKE_FLOAT_CVAR(cs2f_extend_success_ratio, "Ratio needed to pass an extend", g_flExtendSucceedRatio, 0.5f, false)
-FAKE_INT_CVAR(cs2f_extend_time, "Time to add per extend", g_iExtendTimeToAdd, 20, false)
+FAKE_FLOAT_CVAR(cs2f_extend_success_ratio, "Ratio needed to pass an extend vote", g_flExtendSucceedRatio, 0.5f, false)
+FAKE_INT_CVAR(cs2f_extend_time, "Time to add per extend in minutes", g_iExtendTimeToAdd, 20, false)
+FAKE_FLOAT_CVAR(cs2f_extend_vote_start_time, "If cs2f_extend_mode is 3, start an extend vote at this timeleft (minutes)", g_flExtendVoteStartTime, 4.0f, false)
+FAKE_FLOAT_CVAR(cs2f_extend_vote_duration, "Time to leave the extend vote active for (seconds)", g_flExtendVoteDuration, 30.0f, false)
+FAKE_FLOAT_CVAR(cs2f_extend_begin_ratio, "If cs2f_extend_mode is >= 2, Ratio needed to begin an extend vote", g_flExtendBeginRatio, 0.4f, false)
+
+FAKE_FLOAT_CVAR(cs2f_rtv_vote_delay, "Time after map start until RTV votes can be cast", g_flRtvDelay, 120.0f, false)
 FAKE_FLOAT_CVAR(cs2f_rtv_success_ratio, "Ratio needed to pass RTV", g_flRTVSucceedRatio, 0.6f, false)
 FAKE_BOOL_CVAR(cs2f_rtv_endround, "Whether to immediately end the round when RTV succeeds", g_bRTVEndRound, false, false)
+
+static float flExtendVoteTickrate = 1.0f;
+
+void VoteManager_Init()
+{
+	// Disable RTV and Extend votes after map has just started
+	g_RTVState = ERTVState::MAP_START;
+	g_ExtendState = EExtendState::MAP_START;
+
+	new CTimer(g_flExtendVoteDelay, false, true, []()
+		{
+			if (g_ExtendState < EExtendState::POST_EXTEND_NO_EXTENDS_LEFT)
+				g_ExtendState = EExtendState::EXTEND_ALLOWED;
+			return -1.0f;
+		}
+	);
+
+	new CTimer(g_flRtvDelay, false, true, []()
+		{
+			if (g_RTVState != ERTVState::BLOCKED_BY_ADMIN)
+				g_RTVState = ERTVState::RTV_ALLOWED;
+			return -1.0f;
+		}
+	);
+
+	new CTimer(flExtendVoteTickrate, false, true, TimerCheckTimeleft);
+}
+
+int iVoteStartTicks = 3;
+bool bVoteStarting = false;
+float TimerCheckTimeleft()
+{
+	if (!gpGlobals || !g_pGameRules)
+		return flExtendVoteTickrate;
+
+	// Auto votes disabled, dont stop the timer in case this changes mid-map
+	if (g_ExtendVoteMode != EExtendVoteMode::EXTENDVOTE_AUTO)
+		return flExtendVoteTickrate;
+
+	// Vote already happening
+	if (bVoteStarting || g_ExtendState == EExtendState::IN_PROGRESS)
+		return flExtendVoteTickrate;
+
+	// No more extends or map RTVd
+	if (g_iExtendsLeft <= 0 || g_ExtendState >= EExtendState::POST_EXTEND_NO_EXTENDS_LEFT)
+		return flExtendVoteTickrate;
+
+	ConVar* cvar = g_pCVar->GetConVar(g_pCVar->FindConVar("mp_timelimit"));
+	// CONVAR_TODO
+	// HACK: values is actually the cvar value itself, hence this ugly cast.
+	float flTimelimit = *(float*)&cvar->values;
+
+	if (flTimelimit <= 0.0)
+		return flExtendVoteTickrate;
+
+	float flTimeleft = (g_pGameRules->m_flGameStartTime + flTimelimit * 60.0f) - gpGlobals->curtime;
+
+	// Not yet time to start a vote
+	if (flTimeleft > (g_flExtendVoteStartTime * 60.0))
+		return flExtendVoteTickrate;
+
+
+	bVoteStarting = true;
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote starting in 10 seconds!");
+
+	new CTimer(7.0f, false, true, []()
+		{
+			if (iVoteStartTicks == 0)
+			{
+				iVoteStartTicks = 3;
+				StartExtendVote(VOTE_CALLER_SERVER);
+				bVoteStarting = false;
+				return -1.0f;
+			}
+
+			ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote starting in %d....", iVoteStartTicks);
+			iVoteStartTicks--;
+			return 1.0f;
+		}
+	);
+
+	return flExtendVoteTickrate;
+}
 
 int GetCurrentRTVCount()
 {
@@ -115,7 +214,7 @@ int GetNeededExtendCount()
 		}
 	}
 
-	return (int)(iOnlinePlayers * g_flExtendSucceedRatio) + 1;
+	return (int)(iOnlinePlayers * g_flExtendBeginRatio) + 1;
 }
 
 CON_COMMAND_CHAT(rtv, "- Vote to end the current map sooner")
@@ -184,11 +283,11 @@ CON_COMMAND_CHAT(rtv, "- Vote to end the current map sooner")
 			ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "RTV succeeded! Ending the map now...");
 
 			new CTimer(3.0f, false, true, []()
-			{
-				g_pGameRules->TerminateRound(5.0f, CSRoundEndReason::Draw);
+				{
+					g_pGameRules->TerminateRound(5.0f, CSRoundEndReason::Draw);
 
-				return -1.0f;
-			});
+					return -1.0f;
+				});
 		}
 		else
 		{
@@ -207,7 +306,7 @@ CON_COMMAND_CHAT(rtv, "- Vote to end the current map sooner")
 
 	pPlayer->SetRTVVote(true);
 	pPlayer->SetRTVVoteTime(gpGlobals->curtime);
-	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "%s wants to rock the vote (%i voted, %i needed).", player->GetPlayerName(), iCurrentRTVCount+1, iNeededRTVCount);
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "%s wants to rock the vote (%i voted, %i needed).", player->GetPlayerName(), iCurrentRTVCount + 1, iNeededRTVCount);
 }
 
 CON_COMMAND_CHAT(unrtv, "- Remove your vote to end the current map sooner")
@@ -253,6 +352,42 @@ CON_COMMAND_CHAT(ve, "- Vote to extend current map")
 		return;
 	}
 
+	switch (g_ExtendVoteMode)
+	{
+	case EExtendVoteMode::EXTENDVOTE_OFF:
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Extend votes are disabled.");
+		return;
+	case EExtendVoteMode::EXTENDVOTE_ADMINONLY:
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Extend votes are disabled.");
+		return;
+	case EExtendVoteMode::EXTENDVOTE_AUTO:
+	{
+		if (g_ExtendState == EExtendState::EXTEND_ALLOWED)
+		{
+			ConVar* cvar = g_pCVar->GetConVar(g_pCVar->FindConVar("mp_timelimit"));
+
+			// CONVAR_TODO
+			// HACK: values is actually the cvar value itself, hence this ugly cast.
+			float flTimelimit = *(float*)&cvar->values;
+			if (flTimelimit <= 0.0)
+				return;
+
+			float flTimeleft = (g_pGameRules->m_flGameStartTime + flTimelimit * 60.0f) - gpGlobals->curtime;
+			int iTimeTillVote = (int)(flTimeleft - (g_flExtendVoteStartTime * 60.0));
+
+			div_t div = std::div(iTimeTillVote, 60);
+			int iMinutesLeft = div.quot;
+			int iSecondsLeft = div.rem;
+
+			if (iMinutesLeft > 0)
+				ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "An extend vote will start in %im %is", iMinutesLeft, iSecondsLeft);
+			else
+				ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "An extend vote will start in %i seconds", iSecondsLeft);
+			return;
+		}
+	}
+	}
+
 	int iPlayer = player->GetPlayerSlot();
 
 	ZEPlayer* pPlayer = g_playerManager->GetPlayer(iPlayer);
@@ -268,6 +403,9 @@ CON_COMMAND_CHAT(ve, "- Vote to extend current map")
 	{
 	case EExtendState::MAP_START:
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Extend vote is not open yet.");
+		return;
+	case EExtendState::IN_PROGRESS:
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "An extend vote is in progress right now!");
 		return;
 	case EExtendState::POST_EXTEND_COOLDOWN:
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Extend vote is not open yet.");
@@ -304,65 +442,14 @@ CON_COMMAND_CHAT(ve, "- Vote to extend current map")
 
 	if (iCurrentExtendCount + 1 >= iNeededExtendCount)
 	{
-		// mimic behaviour of !extend
-		// CONVAR_TODO
-		ConVar* cvar = g_pCVar->GetConVar(g_pCVar->FindConVar("mp_timelimit"));
-
-		// CONVAR_TODO
-		// HACK: values is actually the cvar value itself, hence this ugly cast.
-		float flTimelimit = *(float *)&cvar->values;
-
-		if (gpGlobals->curtime - g_pGameRules->m_flGameStartTime > flTimelimit * 60)
-			flTimelimit = (gpGlobals->curtime - g_pGameRules->m_flGameStartTime) / 60.0f + g_iExtendTimeToAdd;
-		else
-		{
-			if (flTimelimit == 1)
-				flTimelimit = 0;
-			flTimelimit += g_iExtendTimeToAdd;
-		}
-
-		if (flTimelimit <= 0)
-			flTimelimit = 1;
-		
-		char buf[32];
-		V_snprintf(buf, sizeof(buf), "mp_timelimit %.6f", flTimelimit);
-
-		// CONVAR_TODO
-		g_pEngineServer2->ServerCommand(buf);
-
-		if (g_iExtendsLeft == 1)
-			// there are no extends left after a successfull extend vote
-			g_ExtendState = EExtendState::POST_EXTEND_NO_EXTENDS_LEFT;
-		else
-		{
-			// there's an extend left after a successfull extend vote
-			g_ExtendState = EExtendState::POST_EXTEND_COOLDOWN;
-
-			// Allow another extend vote after added time lapses
-			new CTimer(g_iExtendTimeToAdd * 60.0f, false, true, []()
-			{
-				if (g_ExtendState == EExtendState::POST_EXTEND_COOLDOWN)
-					g_ExtendState = EExtendState::EXTEND_ALLOWED;
-				return -1.0f;
-			});
-		}
-
-		for (int i = 0; i < gpGlobals->maxClients; i++)
-		{
-			ZEPlayer* pPlayer2 = g_playerManager->GetPlayer(i);
-			if (pPlayer2)
-				pPlayer2->SetExtendVote(false);
-		}
-
-		g_iExtendsLeft--;
-		ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote succeeded! Current map has been extended by %i minutes.", g_iExtendTimeToAdd);
+		StartExtendVote(VOTE_CALLER_SERVER);
 
 		return;
 	}
 
 	pPlayer->SetExtendVote(true);
 	pPlayer->SetExtendVoteTime(gpGlobals->curtime);
-	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "%s wants to extend the map (%i voted, %i needed).", player->GetPlayerName(), iCurrentExtendCount+1, iNeededExtendCount);
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "%s wants to extend the map (%i voted, %i needed).", player->GetPlayerName(), iCurrentExtendCount + 1, iNeededExtendCount);
 }
 
 CON_COMMAND_CHAT(unve, "- Remove your vote to extend current map")
@@ -373,6 +460,12 @@ CON_COMMAND_CHAT(unve, "- Remove your vote to extend current map")
 	if (!player)
 	{
 		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command from the server console.");
+		return;
+	}
+
+	if (g_ExtendVoteMode != EExtendVoteMode::EXTENDVOTE_MANUAL)
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Voting to start extend votes is disabled.");
 		return;
 	}
 
@@ -395,6 +488,30 @@ CON_COMMAND_CHAT(unve, "- Remove your vote to extend current map")
 
 	pPlayer->SetExtendVote(false);
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You no longer want to extend current map.");
+}
+
+CON_COMMAND_CHAT_FLAGS(adminve, "Start a vote extend immediately.", ADMFLAG_CHANGEMAP)
+{
+	if (!g_bVoteManagerEnable)
+		return;
+
+	if (g_ExtendVoteMode == EExtendVoteMode::EXTENDVOTE_OFF)
+	{
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Extend votes are disabled.");
+		return;
+	}
+
+	if (g_ExtendState == EExtendState::IN_PROGRESS || bVoteStarting)
+	{
+		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "An extend vote is already in progress.");
+		return;
+	}
+
+	int slot = VOTE_CALLER_SERVER;
+	if (player)
+		slot = player->GetPlayerSlot();
+
+	StartExtendVote(slot);
 }
 
 CON_COMMAND_CHAT_FLAGS(disablertv, "- Disable the ability for players to vote to end current map sooner", ADMFLAG_CHANGEMAP)
@@ -439,16 +556,25 @@ CON_COMMAND_CHAT_FLAGS(enablertv, "- Restore the ability for players to vote to 
 	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX ADMIN_PREFIX "enabled vote for RTV.", pszCommandPlayerName);
 }
 
-CON_COMMAND_CHAT_FLAGS(addextend, "- Add another extend to the current map for players to vote", ADMFLAG_CHANGEMAP)
+CON_COMMAND_CHAT_FLAGS(addextend, "- Add another extend to the current map for players to vote", ADMFLAG_RCON)
 {
 	if (!g_bVoteManagerEnable)
 		return;
+
+	if (g_ExtendState == EExtendState::IN_PROGRESS)
+	{
+		if (player)
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Wait until the current vote has ended to add extends.");
+		else
+			ConMsg("Wait until the current vote has ended to add extends.");
+		return;
+	}
 
 	const char* pszCommandPlayerName = player ? player->GetPlayerName() : "Console";
 
 	if (g_ExtendState == EExtendState::POST_EXTEND_NO_EXTENDS_LEFT || g_ExtendState == EExtendState::NO_EXTENDS)
 		g_ExtendState = EExtendState::EXTEND_ALLOWED;
-	
+
 	g_iExtendsLeft += 1;
 
 	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX ADMIN_PREFIX "allowed for an additional extend.", pszCommandPlayerName);
@@ -492,7 +618,7 @@ CON_COMMAND_CHAT(timeleft, "- Display time left to end of current map.")
 
 	// CONVAR_TODO
 	// HACK: values is actually the cvar value itself, hence this ugly cast.
-	float flTimelimit = *(float *)&cvar->values;
+	float flTimelimit = *(float*)&cvar->values;
 
 	if (flTimelimit == 0.0f)
 	{
@@ -500,7 +626,7 @@ CON_COMMAND_CHAT(timeleft, "- Display time left to end of current map.")
 		return;
 	}
 
-	int iTimeleft = (int) ((g_pGameRules->m_flGameStartTime + flTimelimit * 60.0f) - gpGlobals->curtime);
+	int iTimeleft = (int)((g_pGameRules->m_flGameStartTime + flTimelimit * 60.0f) - gpGlobals->curtime);
 
 	if (iTimeleft < 0)
 	{
@@ -511,9 +637,168 @@ CON_COMMAND_CHAT(timeleft, "- Display time left to end of current map.")
 	div_t div = std::div(iTimeleft, 60);
 	int iMinutesLeft = div.quot;
 	int iSecondsLeft = div.rem;
-	
+
 	if (iMinutesLeft > 0)
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Timeleft: %i minutes %i seconds", iMinutesLeft, iSecondsLeft);
 	else
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Timeleft: %i seconds", iSecondsLeft);
+}
+
+void ExtendMap(int iMinutes)
+{
+	// mimic behaviour of !extend
+		// CONVAR_TODO
+	ConVar* cvar = g_pCVar->GetConVar(g_pCVar->FindConVar("mp_timelimit"));
+
+	// CONVAR_TODO
+	// HACK: values is actually the cvar value itself, hence this ugly cast.
+	float flTimelimit = *(float*)&cvar->values;
+
+	if (gpGlobals->curtime - g_pGameRules->m_flGameStartTime > flTimelimit * 60)
+		flTimelimit = (gpGlobals->curtime - g_pGameRules->m_flGameStartTime) / 60.0f + iMinutes;
+	else
+	{
+		if (flTimelimit == 1)
+			flTimelimit = 0;
+		flTimelimit += iMinutes;
+	}
+
+	if (flTimelimit <= 0)
+		flTimelimit = 1;
+
+	char buf[32];
+	V_snprintf(buf, sizeof(buf), "mp_timelimit %.6f", flTimelimit);
+
+	// CONVAR_TODO
+	g_pEngineServer2->ServerCommand(buf);
+}
+
+void VoteExtendHandler(YesNoVoteAction action, int param1, int param2)
+{
+	switch (action)
+	{
+	case YesNoVoteAction::VoteAction_Start:
+	{
+		ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote started!");
+		break;
+	}
+	case YesNoVoteAction::VoteAction_Vote: // param1 = client slot, param2 = choice (VOTE_OPTION1=yes, VOTE_OPTION2=no)
+	{
+		CCSPlayerController* pController = CCSPlayerController::FromSlot(param1);
+		if (!pController || !pController->IsController() || !pController->IsConnected())
+			break;
+		ClientPrint(pController, HUD_PRINTTALK, CHAT_PREFIX "Thanks for voting! Type !revote to change your vote!");
+		break;
+	}
+	case YesNoVoteAction::VoteAction_End:
+	{
+		if ((YesNoVoteEndReason)param1 == YesNoVoteEndReason::VoteEnd_Cancelled)
+		{
+			// Admin cancelled so stop further automatic votes
+			// It will reenable if an admin manually calls a vote
+			if (g_ExtendVoteMode == EExtendVoteMode::EXTENDVOTE_AUTO)
+			{
+				g_ExtendState = EExtendState::POST_EXTEND_NO_EXTENDS_LEFT;
+			}
+		}
+
+		break;
+	}
+	}
+}
+
+// return true to show vote pass, false to show fail
+bool VoteExtendEndCallback(YesNoVoteInfo info)
+{
+	//ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Vote end: numvotes:%d yes:%d no:%d numclients:%d", info.num_votes, info.yes_votes, info.no_votes, info.num_clients);
+
+	float yes_percent = 0.0f;
+
+	if (info.num_votes > 0)
+		yes_percent = (float)info.yes_votes / (float)info.num_votes;
+
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Vote ended. Yes received %.2f%% of %d votes (Needed %.2f%%)", yes_percent * 100.0f, info.num_votes, g_flExtendSucceedRatio * 100.0f);
+
+	if (yes_percent >= g_flExtendSucceedRatio)
+	{
+		ExtendMap(g_iExtendTimeToAdd);
+
+		if (g_iExtendsLeft == 1)
+			// there are no extends left after a successfull extend vote
+			g_ExtendState = EExtendState::POST_EXTEND_NO_EXTENDS_LEFT;
+		else
+		{
+			// there's an extend left after a successfull extend vote
+			if (g_ExtendVoteMode == EExtendVoteMode::EXTENDVOTE_AUTO)
+			{
+				//small delay to allow cvar change to go through
+				new CTimer(0.1, false, true, []()
+					{
+						g_ExtendState = EExtendState::EXTEND_ALLOWED;
+						return -1.0f;
+					});
+			}
+			else
+			{
+				g_ExtendState = EExtendState::POST_EXTEND_COOLDOWN;
+
+				// Allow another extend vote after added time lapses
+				new CTimer(g_iExtendTimeToAdd * 60.0f, false, true, []()
+					{
+						if (g_ExtendState == EExtendState::POST_EXTEND_COOLDOWN)
+							g_ExtendState = EExtendState::EXTEND_ALLOWED;
+						return -1.0f;
+					});
+			}
+		}
+
+		for (int i = 0; i < gpGlobals->maxClients; i++)
+		{
+			ZEPlayer* pPlayer = g_playerManager->GetPlayer(i);
+			if (pPlayer)
+				pPlayer->SetExtendVote(false);
+		}
+
+		g_iExtendsLeft--;
+		ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote succeeded! Current map has been extended by %i minutes.", g_iExtendTimeToAdd);
+
+		return true;
+	}
+
+	// Vote failed so we don't allow any more player initiated votes
+	g_ExtendState = EExtendState::POST_EXTEND_NO_EXTENDS_LEFT;
+	g_iExtendsLeft = 0;
+
+	ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote failed! Further extend votes disabled!", g_iExtendTimeToAdd);
+
+	return false;
+}
+
+static int iVoteEndTicks = 3;
+void StartExtendVote(int iCaller)
+{
+	if (g_ExtendState == EExtendState::IN_PROGRESS)
+		return;
+
+	char sDetailStr[64];
+	V_snprintf(sDetailStr, sizeof(sDetailStr), "Vote to extend the map for another %d minutes", g_iExtendTimeToAdd);
+
+	g_ExtendState = EExtendState::IN_PROGRESS;
+
+	g_pPanoramaVoteHandler->SendYesNoVoteToAll(g_flExtendVoteDuration, iCaller, "#SFUI_vote_passed_nextlevel_extend",
+		sDetailStr, &VoteExtendEndCallback, &VoteExtendHandler);
+
+	new CTimer(g_flExtendVoteDuration - 3.0f, false, true, []()
+		{
+			if (iVoteEndTicks == 0 || g_ExtendState != EExtendState::IN_PROGRESS)
+			{
+				iVoteEndTicks = 3;
+				return -1.0f;
+			}
+
+			ClientPrintAll(HUD_PRINTTALK, CHAT_PREFIX "Extend vote ending in %d....", iVoteEndTicks);
+			iVoteEndTicks--;
+			return 1.0f;
+		}
+	);
 }

--- a/src/votemanager.h
+++ b/src/votemanager.h
@@ -33,6 +33,7 @@ enum class EExtendState
 {
 	MAP_START,
 	EXTEND_ALLOWED,
+	IN_PROGRESS,
 	POST_EXTEND_COOLDOWN,
 	POST_EXTEND_NO_EXTENDS_LEFT,
 	POST_LAST_ROUND_END,
@@ -40,9 +41,22 @@ enum class EExtendState
 	NO_EXTENDS,
 };
 
+enum EExtendVoteMode
+{
+	EXTENDVOTE_OFF,			// No extend votes can be called
+	EXTENDVOTE_ADMINONLY,	// Only admins can initiate extend votes, all further options also include this
+	EXTENDVOTE_MANUAL,		// Extend votes are triggered by players typing !ve
+	EXTENDVOTE_AUTO,		// Extend votes can be triggered by !ve or when map timelimit reaches a given value
+};
+
 extern ERTVState g_RTVState;
 extern EExtendState g_ExtendState;
 extern int g_iExtendsLeft;
 extern bool g_bVoteManagerEnable;
 
+void VoteManager_Init();
 void SetExtendsLeft();
+void ExtendMap(int iMinutes);
+
+float TimerCheckTimeleft();
+void StartExtendVote(int iCaller);


### PR DESCRIPTION
- Added a way to easily create and handle votes using the f1/f2 vote menu
  - Added `!cancelvote` for admins to cancel an ongoing vote
  - Added `!revote` for players to change their vote
- Added support for extend votes to use panorama vote
- Added cvars to change how and when extend votes happen
- Added command `!adminve` for admins to instantly start an extend vote
- Support for automatic extend votes when a given timeleft is reached