### PR TITLE
Fix default value return in GetPreferenceInt/Float

### DIFF
--- a/src/user_preferences.cpp
+++ b/src/user_preferences.cpp
@@ -169,12 +169,18 @@ const char* CUserPreferencesSystem::GetPreference(int iSlot, const char* sKey, c
 
 int CUserPreferencesSystem::GetPreferenceInt(int iSlot, const char* sKey, int iDefaultValue)
 {
-	return V_StringToInt32(GetPreference(iSlot, sKey, ""), iDefaultValue);
+	const char* pszPreferenceValue = GetPreference(iSlot, sKey, "");
+	if (*pszPreferenceValue == '\0')
+		return iDefaultValue;
+	return V_StringToInt32(pszPreferenceValue, iDefaultValue);
 }
 
 float CUserPreferencesSystem::GetPreferenceFloat(int iSlot, const char* sKey, float fDefaultValue)
 {
-	return V_StringToFloat32(GetPreference(iSlot, sKey, ""), fDefaultValue);
+	const char* pszPreferenceValue = GetPreference(iSlot, sKey, "");
+	if (*pszPreferenceValue == '\0')
+		return fDefaultValue;
+	return V_StringToFloat32(pszPreferenceValue, fDefaultValue);
 }
 
 void CUserPreferencesSystem::SetPreference(int iSlot, const char* sKey, const char* sValue)


### PR DESCRIPTION
Currently `GetPreference(iSlot, sKey, "");` passes a `""` default value to `V_StringToInt32` if preference is not found. That empty string gets parsed properly by `V_StringToInt32`, causing it to not return the default value passed to `GetPreferenceInt/Float`.