### PR TITLE
Add map cooldown and min/max player configuration, saving of map cooldown state

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -78,6 +78,7 @@ cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
 cs2f_rtv_endround 				0		// Whether to immediately end the round when RTV succeeds
 
 // Map vote settings
+cs2f_vote_maps_cooldown 		10		// Default number of maps to wait until a map can be voted / nominated again i.e. cooldown.
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -78,7 +78,6 @@ cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
 cs2f_rtv_endround 				0		// Whether to immediately end the round when RTV succeeds
 
 // Map vote settings
-cs2f_vote_maps_cooldown 		10		// Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -3,20 +3,24 @@
 	"de_dust2"
 	{
 		"enabled" "1"
+		"cooldown" "1"
 	}
 	"ze_my_first_ze_map"
 	{
 		"workshop_id" "123"
 		"enabled" "1"
+		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
+		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
+		"cooldown" "1"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -9,22 +9,22 @@
 	{
 		"workshop_id" "123"
 		"enabled" "1"
-		"minPlayers" "30"
+		"min_players" "30"
 		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
-		"minPlayers" "5"
-		"maxPlayers" "10"
+		"min_players" "5"
+		"max_players" "10"
 		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
-		"maxPlayers" "20"
+		"max_players" "20"
 		"cooldown" "1"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -9,18 +9,22 @@
 	{
 		"workshop_id" "123"
 		"enabled" "1"
+		"minPlayers" "30"
 		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
+		"minPlayers" "5"
+		"maxPlayers" "10"
 		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
+		"maxPlayers" "20"
 		"cooldown" "1"
 	}
 }

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -741,9 +741,9 @@ bool CMapVoteSystem::LoadMapList()
 		CMapInfo map = m_vecMapList[i];
 
 		if (map.GetWorkshopId() == 0)
-			ConMsg("Map %d is %s, which is %s. MinPlayers: %llu MaxPlayers: %llu Cooldown: %d\n", i, map.GetName(), map.IsEnabled() ? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
+			ConMsg("Map %d is %s, which is %s. MinPlayers: %d MaxPlayers: %d Cooldown: %d\n", i, map.GetName(), map.IsEnabled() ? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
 		else
-			ConMsg("Map %d is %s with workshop id %llu, which is %s. MinPlayers: %llu MaxPlayers: %llu Cooldown: %d\n", i, map.GetName(), map.GetWorkshopId(), map.IsEnabled()? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
+			ConMsg("Map %d is %s with workshop id %llu, which is %s. MinPlayers: %d MaxPlayers: %d Cooldown: %d\n", i, map.GetName(), map.GetWorkshopId(), map.IsEnabled()? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
 	}
 
 	m_bMapListLoaded = true;

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -208,6 +208,24 @@ CON_COMMAND_CHAT(nomlist, "- List the list of nominations")
 	}
 }
 
+CON_COMMAND_CHAT(mapcooldowns, "- List the maps currently in cooldown")
+{
+	if (!g_bVoteManagerEnable)
+		return;
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "The list of maps in cooldown will be shown in console.");
+	ClientPrint(player, HUD_PRINTCONSOLE, "The list of maps in cooldown is:");
+	int iMapCount = g_pMapVoteSystem->GetMapListSize();
+	for (int iMapIndex = 0; iMapIndex < iMapCount; iMapIndex++) {
+		int iCooldown = g_pMapVoteSystem->GetCooldownMap(iMapIndex);
+		if (iCooldown > 0 && g_pMapVoteSystem->GetMapEnabledStatus(iMapIndex))
+		{
+			const char* sMapName = g_pMapVoteSystem->GetMapName(iMapIndex);
+			ClientPrint(player, HUD_PRINTCONSOLE, "- %s (%d maps remaining)", sMapName, iCooldown);
+		}
+	}
+}
+
 GAME_EVENT_F(cs_win_panel_match)
 {
 	if (g_bVoteManagerEnable && !g_pMapVoteSystem->IsVoteOngoing())

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -806,3 +806,28 @@ bool CMapVoteSystem::WriteMapCooldownsToFile()
 
 	return true;
 }
+
+void CMapVoteSystem::ClearInvalidNominations()
+{
+	if (!g_bVoteManagerEnable || m_bIsVoteOngoing)
+		return;
+
+	for (int i = 0; i < gpGlobals->maxClients; i++) {
+		int iNominatedMapIndex = m_arrPlayerNominations[i];
+
+		// Ignore unset nominations (negative index)
+		if (iNominatedMapIndex < 0)
+			continue;
+
+		// Check if nominated index still meets criteria for nomination
+		if (!IsMapIndexEnabled(iNominatedMapIndex))
+		{
+			ClearPlayerInfo(i);
+			CCSPlayerController* pPlayer = CCSPlayerController::FromSlot(i);
+			if (!pPlayer)
+				continue;
+
+			ClientPrint(pPlayer, HUD_PRINTTALK, CHAT_PREFIX "Your nomination for \x06%s \x01has been removed because the player count requirements are no longer met.", GetMapName(iNominatedMapIndex));
+		}
+	}
+}

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -667,9 +667,9 @@ bool CMapVoteSystem::LoadMapList()
 		const char *pszName = pKey->GetName();
 		uint64 iWorkshopId = pKey->GetUint64("workshop_id");
 		bool bIsEnabled = pKey->GetBool("enabled", true);
+		int iMinPlayers = pKey->GetInt("minPlayers", 0);
+		int iMaxPlayers = pKey->GetInt("maxPlayers", 64);
 		int iBaseCooldown = pKey->GetInt("cooldown");
-		int iMinPlayers = pKey->GetInt("MinPlayers", 0);
-		int iMaxPlayers = pKey->GetInt("MaxPlayers", 64);
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 
 		if (iWorkshopId != 0)

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -72,6 +72,21 @@ CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current
 	Message("Map list reloaded\n");
 }
 
+CON_COMMAND_F(cs2f_vote_maps_cooldown, "Default number of maps to wait until a map can be voted / nominated again i.e. cooldown.", FCVAR_LINKED_CONCOMMAND | FCVAR_SPONLY)
+{
+	if (!g_pMapVoteSystem) {
+		Message("The map vote subsystem is not enabled.\n");
+		return;
+	}
+
+	if (args.ArgC() < 2)
+		Message("%s %d\n", args[0], g_pMapVoteSystem->GetDefaultMapCooldown());
+	else {
+		int iCurrentCooldown = g_pMapVoteSystem->GetDefaultMapCooldown();
+		g_pMapVoteSystem->SetDefaultMapCooldown(V_StringToInt32(args[1], iCurrentCooldown));
+	}
+}
+
 CON_COMMAND_F(cs2f_vote_max_nominations, "Number of nominations to include per vote, out of a maximum of 10.", FCVAR_LINKED_CONCOMMAND | FCVAR_SPONLY)
 {
 	if (!g_pMapVoteSystem) {
@@ -698,7 +713,7 @@ bool CMapVoteSystem::LoadMapList()
 		bool bIsEnabled = pKey->GetBool("enabled", true);
 		int iMinPlayers = pKey->GetInt("min_players", 0);
 		int iMaxPlayers = pKey->GetInt("max_players", 64);
-		int iBaseCooldown = pKey->GetInt("cooldown");
+		int iBaseCooldown = pKey->GetInt("cooldown", m_iDefaultMapCooldown);
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 
 		if (iWorkshopId != 0)

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -678,8 +678,8 @@ bool CMapVoteSystem::LoadMapList()
 		const char *pszName = pKey->GetName();
 		uint64 iWorkshopId = pKey->GetUint64("workshop_id");
 		bool bIsEnabled = pKey->GetBool("enabled", true);
-		int iMinPlayers = pKey->GetInt("minPlayers", 0);
-		int iMaxPlayers = pKey->GetInt("maxPlayers", 64);
+		int iMinPlayers = pKey->GetInt("min_players", 0);
+		int iMaxPlayers = pKey->GetInt("max_players", 64);
 		int iBaseCooldown = pKey->GetInt("cooldown");
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -687,7 +687,7 @@ bool CMapVoteSystem::LoadMapList()
 	// Load map cooldowns from file
 	KeyValues* pKVcooldowns = new KeyValues("cooldowns");
 	KeyValues::AutoDelete autoDeleteKVcooldowns(pKVcooldowns);
-	const char *pszCooldownFilePath = "addons/cs2fixes/configs/cooldowns.cfg";
+	const char *pszCooldownFilePath = "addons/cs2fixes/data/cooldowns.txt";
 	if (!pKVcooldowns->LoadFromFile(g_pFullFileSystem, pszCooldownFilePath)) {
 		Message("Failed to load cooldown file at %s - resetting all cooldowns to 0\n", pszCooldownFilePath);
 	}
@@ -774,7 +774,7 @@ bool CMapVoteSystem::WriteMapCooldownsToFile()
 	KeyValues* pKV = new KeyValues("cooldowns");
 	KeyValues::AutoDelete autoDelete(pKV);
 
-	const char *pszPath = "addons/cs2fixes/configs/cooldowns.cfg";
+	const char *pszPath = "addons/cs2fixes/data/cooldowns.txt";
 
 	FOR_EACH_VEC(m_vecMapList, i)
 	{

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -134,6 +134,7 @@ public:
     bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
     int GetDefaultMapCooldown() { return m_iDefaultMapCooldown; }
     void SetDefaultMapCooldown(int iMapCooldown) { m_iDefaultMapCooldown = iMapCooldown; }
+    void ClearInvalidNominations();
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -47,13 +47,13 @@ namespace NominationReturnCodes
 class CMapInfo
 {
 public:
-    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown)
+    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown, int iCurrentCooldown)
     {
         V_strcpy(m_pszName, pszName);
         m_iWorkshopId = iWorkshopId;
         m_bIsEnabled = bIsEnabled;
         m_iBaseCooldown = iBaseCooldown;
-        m_iCurrentCooldown = 0;
+        m_iCurrentCooldown = iCurrentCooldown;
     }
 
     const char* GetName() { return (const char*)m_pszName; };
@@ -126,6 +126,7 @@ private:
     int WinningMapIndex();
     bool UpdateWinningMap();
     void GetNominatedMapsForVote(CUtlVector<int>& vecChosenNominatedMaps);
+    bool WriteMapCooldownsToFile();
 
     STEAM_GAMESERVER_CALLBACK_MANUAL(CMapVoteSystem, OnMapDownloaded, DownloadItemResult_t, m_CallbackDownloadItemResult);
     CUtlQueue<PublishedFileId_t> m_DownloadQueue;

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -132,6 +132,8 @@ public:
     int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
     int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
     bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
+    int GetDefaultMapCooldown() { return m_iDefaultMapCooldown; }
+    void SetDefaultMapCooldown(int iMapCooldown) { m_iDefaultMapCooldown = iMapCooldown; }
 
 private:
     int WinningMapIndex();
@@ -145,6 +147,7 @@ private:
     CUtlVector<CMapInfo> m_vecMapList;
     int m_arrPlayerNominations[MAXPLAYERS];
     int m_iForcedNextMapIndex = -1;
+    int m_iDefaultMapCooldown = 10;
     int m_iMaxNominatedMaps = 10;
     int m_iRandomWinnerShift = 0;
     int m_arrPlayerVotes[MAXPLAYERS];

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -82,9 +82,8 @@ private:
 typedef struct
 {
     const char* name;
-    int cooldown;
-    int mapIndex;
-} MapCooldownStruct;
+    int index;
+} MapIndexPair;
 
 
 class CMapVoteSystem
@@ -130,6 +129,8 @@ public:
     int GetDownloadQueueSize() { return m_DownloadQueue.Count(); }
     int GetCurrentMapIndex() { return m_iCurrentMapIndex; }
     void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
+    int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
+    int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -131,6 +131,7 @@ public:
     void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
     int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
     int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
+    bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -77,7 +77,8 @@ typedef struct
 {
     const char* name;
     int cooldown;
-} MapCooldownPair;
+    int mapIndex;
+} MapCooldownStruct;
 
 
 class CMapVoteSystem
@@ -99,7 +100,7 @@ public:
     int GetMapIndexFromSubstring(const char* sMapSubstring);
     int GetCooldownMap(int iMapIndex) { return m_vecMapList[iMapIndex].GetCooldown(); };
     void PutMapOnCooldown(int iMapIndex) { m_vecMapList[iMapIndex].ResetCooldownToBase(); };
-    void PutMapOnCooldownAndDecrement(int iMapIndex);
+    void DecrementAllMapCooldowns();
     void SetMaxNominatedMaps(int iMaxNominatedMaps) { m_iMaxNominatedMaps = iMaxNominatedMaps; };
     int GetMaxNominatedMaps() { return m_iMaxNominatedMaps; };
     int AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
@@ -121,6 +122,8 @@ public:
     uint64 GetCurrentWorkshopMap() { return m_iCurrentWorkshopMap; }
     const char* GetCurrentMap() { return m_strCurrentMap.c_str(); }
     int GetDownloadQueueSize() { return m_DownloadQueue.Count(); }
+    int GetCurrentMapIndex() { return m_iCurrentMapIndex; }
+    void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
 
 private:
     int WinningMapIndex();
@@ -137,6 +140,7 @@ private:
     int m_iMaxNominatedMaps = 10;
     int m_iRandomWinnerShift = 0;
     int m_arrPlayerVotes[MAXPLAYERS];
+    int m_iCurrentMapIndex;
     bool m_bIsVoteOngoing = false;
     bool m_bMapListLoaded = false;
     bool m_bIntermissionStarted = false;

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -47,13 +47,15 @@ namespace NominationReturnCodes
 class CMapInfo
 {
 public:
-    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown, int iCurrentCooldown)
+    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iMinPlayers, int iMaxPlayers, int iBaseCooldown, int iCurrentCooldown)
     {
         V_strcpy(m_pszName, pszName);
         m_iWorkshopId = iWorkshopId;
         m_bIsEnabled = bIsEnabled;
         m_iBaseCooldown = iBaseCooldown;
         m_iCurrentCooldown = iCurrentCooldown;
+        m_iMinPlayers = iMinPlayers;
+        m_iMaxPlayers = iMaxPlayers;
     }
 
     const char* GetName() { return (const char*)m_pszName; };
@@ -63,11 +65,15 @@ public:
     int GetCooldown() { return m_iCurrentCooldown; };
     void ResetCooldownToBase() { m_iCurrentCooldown = m_iBaseCooldown; };
     void DecrementCooldown() { m_iCurrentCooldown = MAX(0, (m_iCurrentCooldown - 1)); }
+    int GetMinPlayers() { return m_iMinPlayers; };
+    int GetMaxPlayers() { return m_iMaxPlayers; };
 
 private:
     char m_pszName[64];
     uint64 m_iWorkshopId;
     bool m_bIsEnabled;
+    int m_iMinPlayers;
+    int m_iMaxPlayers;
     int m_iBaseCooldown;
     int m_iCurrentCooldown;
 };

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -610,6 +610,7 @@ bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid, const char
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
+	g_pMapVoteSystem->ClearInvalidNominations();
 	
 	return true;
 }
@@ -627,6 +628,7 @@ void CPlayerManager::OnClientDisconnect(CPlayerSlot slot)
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
+	g_pMapVoteSystem->ClearInvalidNominations();
 
 	g_pPanoramaVoteHandler->RemovePlayerFromVote(slot.Get());
 }


### PR DESCRIPTION
Adds a new values to maplist.cfg:

"cooldown"
- Use this to configure the cooldown length of each map individually

"minPlayers"
- Set the minimum players required to be online to nominate the map

"maxPlayers"
- Set the maximum player limit for nominating the map

Map cooldowns are counted at the end of next map vote instead of at the end of the current one, matching the old CS:GO map manager behaviour.

Using !nominate without any arguments and without having nominated a map will instead list all maps and their cooldowns in console. If a map cannot be nominated due to Min/Max player limits, it will display this information.

Writes cooldown keyvalues to "addons/cs2fixes/configs/cooldowns.cfg" whenever map cooldowns are decremented. This file will be read when the map list is loaded to restore the remaining cooldown lengths from the previous session. If not found, all maps will start as available to nominate.