### PR TITLE
Update patching

### DIFF
--- a/gamedata/cs2fixes.games.txt
+++ b/gamedata/cs2fixes.games.txt
@@ -87,13 +87,6 @@
 				"windows"		"\x3C\x01\x49\x8B\x5B\x10\x49\x8B\x7B\x18\x0F\x97\xC0\x41\x0F\x28"
 				"linux"		 	"\x3C\x01\x0F\x97\xC0\x48\x81\xC4\x50\x01"
 			}
-			// String: "PlayerMove_PostMove", generally function called before the postmove func is CategorizePosition, find the == 1.0 check in CategorizePosition
-			"CategorizeUnderwater"
-			{
-				"library"		"server"
-				"windows"		"\x81\x04\x04\x2A\x2A\x0F\x2E\x05\x2A\x2A\x2A\x2A\x7A\x2A\x75"
-				"linux"			"\x0F\x45\xC2\x4D\x85\xC0\x0F\x95\xC2\x20\xC2"
-			}
 			// Called right after "Removed %s(%s)\n"
 			"UTIL_Remove"
 			{
@@ -441,11 +434,6 @@
 				"windows"		"128"
 				"linux"			"129"
 			}
-			"CategorizeUnderwater"
-			{
-				"windows"		"14"
-				"linux"			"0"
-			}
 		}
 		"Patches"
 		{
@@ -464,11 +452,6 @@
 			{
 				"windows"		"\x3C\x02"
 				"linux"			"\x3C\x02"
-			}
-			"CategorizeUnderwater"
-			{
-				"windows"		"\x72"
-				"linux"			"\x0F\x42"
 			}
 			// Jumping over a check for nav mesh
 			"BotNavIgnore"

--- a/gamedata/cs2fixes.games.txt
+++ b/gamedata/cs2fixes.games.txt
@@ -91,7 +91,7 @@
 			"CategorizeUnderwater"
 			{
 				"library"		"server"
-				"windows"		"\x76\x2A\xB0\x01\xEB\x2A\x32\xC0\x45\x84\xF6"
+				"windows"		"\x81\x04\x04\x2A\x2A\x0F\x2E\x05\x2A\x2A\x2A\x2A\x7A\x2A\x75"
 				"linux"			"\x0F\x45\xC2\x4D\x85\xC0\x0F\x95\xC2\x20\xC2"
 			}
 			// Called right after "Removed %s(%s)\n"
@@ -441,6 +441,11 @@
 				"windows"		"128"
 				"linux"			"129"
 			}
+			"CategorizeUnderwater"
+			{
+				"windows"		"14"
+				"linux"			"0"
+			}
 		}
 		"Patches"
 		{
@@ -462,7 +467,7 @@
 			}
 			"CategorizeUnderwater"
 			{
-				"windows"		"\x73"
+				"windows"		"\x72"
 				"linux"			"\x0F\x42"
 			}
 			// Jumping over a check for nav mesh

--- a/src/mempatch.cpp
+++ b/src/mempatch.cpp
@@ -30,7 +30,7 @@ bool CMemPatch::PerformPatch(CGameConfig *gameConfig)
 	// If we already have an address, no need to look for it again
 	if (!m_pPatchAddress)
 	{
-		m_pPatchAddress = gameConfig->ResolveSignature(m_pSignatureName);
+		m_pPatchAddress = (uintptr_t*)gameConfig->ResolveSignature(m_pSignatureName);
 
 		if (!m_pPatchAddress)
 			return false;
@@ -45,6 +45,18 @@ bool CMemPatch::PerformPatch(CGameConfig *gameConfig)
 	m_pPatch = gameConfig->HexToByte(patch, m_iPatchLength);
 	if (!m_pPatch)
 		return false;
+
+	if (V_strcmp(m_pOffsetName, ""))
+	{
+		m_iOffset = gameConfig->GetOffset(m_pOffsetName);
+		if (m_iOffset == -1)
+		{
+			Panic("Failed to find offset %s for patch %s\n", m_pOffsetName, m_pszName);
+			return false;
+		}
+
+		m_pPatchAddress += m_iOffset;
+	}
 
 	m_pOriginalBytes = new byte[m_iPatchLength];
 	V_memcpy(m_pOriginalBytes, m_pPatchAddress, m_iPatchLength);

--- a/src/mempatch.cpp
+++ b/src/mempatch.cpp
@@ -30,7 +30,7 @@ bool CMemPatch::PerformPatch(CGameConfig *gameConfig)
 	// If we already have an address, no need to look for it again
 	if (!m_pPatchAddress)
 	{
-		m_pPatchAddress = (uintptr_t*)gameConfig->ResolveSignature(m_pSignatureName);
+		m_pPatchAddress = (uintptr_t)gameConfig->ResolveSignature(m_pSignatureName);
 
 		if (!m_pPatchAddress)
 			return false;
@@ -59,9 +59,9 @@ bool CMemPatch::PerformPatch(CGameConfig *gameConfig)
 	}
 
 	m_pOriginalBytes = new byte[m_iPatchLength];
-	V_memcpy(m_pOriginalBytes, m_pPatchAddress, m_iPatchLength);
+	V_memcpy(m_pOriginalBytes, (void*)m_pPatchAddress, m_iPatchLength);
 
-	Plat_WriteMemory(m_pPatchAddress, (byte*)m_pPatch, m_iPatchLength);
+	Plat_WriteMemory((void*)m_pPatchAddress, (byte*)m_pPatch, m_iPatchLength);
 
 	Message("Patched %s at %p\n", m_pszName, m_pPatchAddress);
 	return true;
@@ -74,7 +74,7 @@ void CMemPatch::UndoPatch()
 
 	Message("Undoing patch %s at %p\n", m_pszName, m_pPatchAddress);
 
-	Plat_WriteMemory(m_pPatchAddress, m_pOriginalBytes, m_iPatchLength);
+	Plat_WriteMemory((void*)m_pPatchAddress, m_pOriginalBytes, m_iPatchLength);
 
 	delete[] m_pOriginalBytes;
 }

--- a/src/mempatch.h
+++ b/src/mempatch.h
@@ -30,7 +30,7 @@ public:
 		m_pSignatureName(pSignatureName), m_pszName(pszName), m_pOffsetName(pOffsetName)
 	{
 		m_pModule = nullptr;
-		m_pPatchAddress = nullptr;
+		m_pPatchAddress = 0x00;
 		m_pOriginalBytes = nullptr;
 		m_pSignature = nullptr;
 		m_pPatch = nullptr;
@@ -41,7 +41,7 @@ public:
 	bool PerformPatch(CGameConfig *gameConfig);
 	void UndoPatch();
 
-	void *GetPatchAddress() { return m_pPatchAddress; }
+	uintptr_t GetPatchAddress() { return m_pPatchAddress; }
 
 private:
 	CModule **m_pModule;
@@ -53,5 +53,5 @@ private:
 	const char *m_pOffsetName;
 	int m_iOffset;
 	size_t m_iPatchLength;
-	uintptr_t *m_pPatchAddress;
+	uintptr_t m_pPatchAddress;
 };

--- a/src/mempatch.h
+++ b/src/mempatch.h
@@ -26,8 +26,8 @@
 class CMemPatch
 {
 public:
-	CMemPatch(const char *pSignatureName, const char *pszName) :
-		m_pSignatureName(pSignatureName), m_pszName(pszName)
+	CMemPatch(const char *pSignatureName, const char *pszName ,const char *pOffsetName = "") :
+		m_pSignatureName(pSignatureName), m_pszName(pszName), m_pOffsetName(pOffsetName)
 	{
 		m_pModule = nullptr;
 		m_pPatchAddress = nullptr;
@@ -35,6 +35,7 @@ public:
 		m_pSignature = nullptr;
 		m_pPatch = nullptr;
 		m_iPatchLength = 0;
+		m_iOffset = 0;
 	}
 
 	bool PerformPatch(CGameConfig *gameConfig);
@@ -49,6 +50,8 @@ private:
 	byte *m_pOriginalBytes;
 	const char *m_pSignatureName;
 	const char *m_pszName;
+	const char *m_pOffsetName;
+	int m_iOffset;
 	size_t m_iPatchLength;
-	void *m_pPatchAddress;
+	uintptr_t *m_pPatchAddress;
 };

--- a/src/patches.cpp
+++ b/src/patches.cpp
@@ -35,7 +35,7 @@ CMemPatch g_CommonPatches[] =
 {
 	CMemPatch("ServerMovementUnlock", "ServerMovementUnlock"),
 	CMemPatch("CheckJumpButtonWater", "FixWaterFloorJump"),
-	CMemPatch("CategorizeUnderwater", "CategorizeUnderwater"),
+	CMemPatch("CategorizeUnderwater", "CategorizeUnderwater", "CategorizeUnderwater"),
 	CMemPatch("WaterLevelGravity", "WaterLevelGravity"),
 	CMemPatch("CPhysBox_Use", "CPhysBox_Use"),
 	CMemPatch("BotNavIgnore", "BotNavIgnore"),

--- a/src/patches.cpp
+++ b/src/patches.cpp
@@ -35,7 +35,6 @@ CMemPatch g_CommonPatches[] =
 {
 	CMemPatch("ServerMovementUnlock", "ServerMovementUnlock"),
 	CMemPatch("CheckJumpButtonWater", "FixWaterFloorJump"),
-	CMemPatch("CategorizeUnderwater", "CategorizeUnderwater", "CategorizeUnderwater"),
 	CMemPatch("WaterLevelGravity", "WaterLevelGravity"),
 	CMemPatch("CPhysBox_Use", "CPhysBox_Use"),
 	CMemPatch("BotNavIgnore", "BotNavIgnore"),


### PR DESCRIPTION
- Add an offset parameter to CMemPatch to allow for offsetting a patch by the number of bytes specified in the offset.
- Remove CategorizeUnderwater because it has never worked on linux and now doesnt work on windows either