### PR TITLE
Let zombies pick up weapon_c4

### DIFF
--- a/configs/zr/weapons.cfg.example
+++ b/configs/zr/weapons.cfg.example
@@ -10,7 +10,7 @@
 	// Gear
 	"c4"
 	{
-		"enabled"		"0"
+		"enabled"		"1"
 	}
 	"knife"
 	{

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -1409,7 +1409,7 @@ bool ZR_Detour_CCSPlayer_WeaponServices_CanUse(CCSPlayer_WeaponServices *pWeapon
 	if (!pPawn)
 		return false;
 	const char *pszWeaponClassname = pPlayerWeapon->GetClassname();
-	if (pPawn->m_iTeamNum() == CS_TEAM_T && V_strncmp(pszWeaponClassname, "weapon_knife", 12))
+	if (pPawn->m_iTeamNum() == CS_TEAM_T && V_strncmp(pszWeaponClassname, "weapon_knife", 12) && V_strncmp(pszWeaponClassname, "weapon_c4", 9))
 		return false;
 	if (pPawn->m_iTeamNum() == CS_TEAM_CT && V_strlen(pszWeaponClassname) > 7 && !g_pZRWeaponConfig->FindWeapon(pszWeaponClassname + 7))
 		return false;


### PR DESCRIPTION
Allows for maps to use weapon_c4 as zombie items that can be dropped to other zombie. This in turn means when the ZM item holder dies, the ZM item can still potentially be used.