### PR TITLE
Add nemesis mode + 'convar'

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -87,6 +87,7 @@ zr_knockback_scale				5.0		// Global knockback scale
 zr_ztele_max_distance 			150.0	// Maximum distance players are allowed to move after starting ztele
 zr_ztele_allow_humans 			0		// Whether to allow humans to use ztele
 zr_infect_spawn_type			1		// Type of Mother Zombies Spawn [0 = MZ spawn where they stand, 1 = MZ get teleported back to spawn on being picked]
+zr_nemesis_mode					0		// Whether to enable Nemesis mode (CTs die but do not swap teams when stabbed)
 zr_infect_spawn_time_min		15		// Minimum time in which Mother Zombies should be picked, after round start
 zr_infect_spawn_time_max		15		// Maximum time in which Mother Zombies should be picked, after round start
 zr_infect_spawn_mz_ratio		7		// Ratio of all Players to Mother Zombies to be spawned at round start


### PR DESCRIPTION
- Add convar ``zr_nemesis_mode`` to disable infections during EZRRoundState::POST_INFECTION. Zombies knifing instead instantly kills CTs, does not swap their team, and leaves them dead. Dead zombie respawning will still be controlled as normal with ``g_bRespawnEnabled``.
- Make it so if ``zr_nemesis_mode`` and ``mp_respawn_on_death_ct`` are both true, do not end the round when all CTs die (as they will still respawn as CT). Ignore the T respawning cvar, as T respawning is controlled by ``g_bRespawnEnabled``.