### PR TITLE
Lots of map system updates

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -78,6 +78,7 @@ cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
 cs2f_rtv_endround 				0		// Whether to immediately end the round when RTV succeeds
 
 // Map vote settings
+cs2f_vote_maps_cooldown 		10		// Default number of maps to wait until a map can be voted / nominated again i.e. cooldown.
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -78,7 +78,6 @@ cs2f_rtv_success_ratio 			0.6		// Ratio needed to pass RTV
 cs2f_rtv_endround 				0		// Whether to immediately end the round when RTV succeeds
 
 // Map vote settings
-cs2f_vote_maps_cooldown 		10		// Number of maps to wait until a map can be voted / nominated again i.e. cooldown.
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10.
 
 // User preferences settings

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -3,20 +3,24 @@
 	"de_dust2"
 	{
 		"enabled" "1"
+		"cooldown" "1"
 	}
 	"ze_my_first_ze_map"
 	{
 		"workshop_id" "123"
 		"enabled" "1"
+		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
+		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
+		"cooldown" "1"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -9,22 +9,22 @@
 	{
 		"workshop_id" "123"
 		"enabled" "1"
-		"minPlayers" "30"
+		"min_players" "30"
 		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
-		"minPlayers" "5"
-		"maxPlayers" "10"
+		"min_players" "5"
+		"max_players" "10"
 		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
-		"maxPlayers" "20"
+		"max_players" "20"
 		"cooldown" "1"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -9,18 +9,22 @@
 	{
 		"workshop_id" "123"
 		"enabled" "1"
+		"minPlayers" "30"
 		"cooldown" "2"
 	}
 	"ze_my_second_ze_map"
 	{
 		"workshop_id" "456"
 		"enabled" "1"
+		"minPlayers" "5"
+		"maxPlayers" "10"
 		"cooldown" "3"
 	}
 	"ze_my_third_ze_map"
 	{
 		"workshop_id" "789"
 		"enabled" "1"
+		"maxPlayers" "20"
 		"cooldown" "1"
 	}
 }

--- a/configs/maplist.cfg.example
+++ b/configs/maplist.cfg.example
@@ -3,7 +3,6 @@
 	"de_dust2"
 	{
 		"enabled" "1"
-		"cooldown" "1"
 	}
 	"ze_my_first_ze_map"
 	{

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -591,7 +591,7 @@ CON_COMMAND_CHAT_FLAGS(map, "<mapname> - Change map", ADMFLAG_CHANGEMAP)
 	for (int i = 0; sMapName[i]; i++)
 	{
 		// Injection prevention, because we may pass user input to ServerCommand
-		if (sMapName[i] == ';')
+		if (sMapName[i] == ';' || sMapName[i] == '|')
 			return;
 
 		sMapName[i] = tolower(sMapName[i]);
@@ -604,12 +604,12 @@ CON_COMMAND_CHAT_FLAGS(map, "<mapname> - Change map", ADMFLAG_CHANGEMAP)
 		std::string sCommand;
 
 		// Check if input is numeric (workshop ID)
-		// Not safe to expose until crashing on failed workshop addon downloads is fixed
-		/*if (V_StringToUint64(pszMapName, 0) != 0)
+		// Not safe to expose to all admins until crashing on failed workshop addon downloads is fixed
+		if ((!player || player->GetZEPlayer()->IsAdminFlagSet(ADMFLAG_RCON)) && V_StringToUint64(pszMapName, 0) != 0)
 		{
 			sCommand = "host_workshop_map " + sMapName;
-		}*/
-		if (g_bVoteManagerEnable && g_pMapVoteSystem->GetMapIndexFromSubstring(pszMapName) != -1)
+		}
+		else if (g_bVoteManagerEnable && g_pMapVoteSystem->GetMapIndexFromSubstring(pszMapName) != -1)
 		{
 			sCommand = "host_workshop_map " + std::to_string(g_pMapVoteSystem->GetMapWorkshopId(g_pMapVoteSystem->GetMapIndexFromSubstring(pszMapName)));
 		}

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -602,6 +602,7 @@ CON_COMMAND_CHAT_FLAGS(map, "<mapname> - Change map", ADMFLAG_CHANGEMAP)
 	if (!g_pEngineServer2->IsMapValid(pszMapName))
 	{
 		std::string sCommand;
+		std::vector<int> foundIndexes = g_pMapVoteSystem->GetMapIndexesFromSubstring(pszMapName);
 
 		// Check if input is numeric (workshop ID)
 		// Not safe to expose to all admins until crashing on failed workshop addon downloads is fixed
@@ -609,9 +610,19 @@ CON_COMMAND_CHAT_FLAGS(map, "<mapname> - Change map", ADMFLAG_CHANGEMAP)
 		{
 			sCommand = "host_workshop_map " + sMapName;
 		}
-		else if (g_bVoteManagerEnable && g_pMapVoteSystem->GetMapIndexFromSubstring(pszMapName) != -1)
+		else if (g_bVoteManagerEnable && foundIndexes.size() > 0)
 		{
-			sCommand = "host_workshop_map " + std::to_string(g_pMapVoteSystem->GetMapWorkshopId(g_pMapVoteSystem->GetMapIndexFromSubstring(pszMapName)));
+			if (foundIndexes.size() > 1)
+			{
+				ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Multiple maps matched \x06%s\x01, try being more specific:", pszMapName);
+
+				for (int i = 0; i < foundIndexes.size() && i < 5; i++)
+					ClientPrint(player, HUD_PRINTTALK, "- %s", g_pMapVoteSystem->GetMapName(foundIndexes[i]));
+
+				return;
+			}
+
+			sCommand = "host_workshop_map " + std::to_string(g_pMapVoteSystem->GetMapWorkshopId(foundIndexes[0]));
 		}
 		else
 		{

--- a/src/leader.cpp
+++ b/src/leader.cpp
@@ -90,21 +90,6 @@ FAKE_INT_CVAR(cs2f_leader_max_glows, "Max amount of glows set by leaders (doesn'
 FAKE_INT_CVAR(cs2f_leader_max_tracers, "Max amount of tracers set by leaders (doesn't impact admins)", g_iMaxTracers, 3, false)
 FAKE_INT_CVAR(cs2f_leader_max_beacons, "Max amount of beacons set by leaders (doesn't impact admins)", g_iMaxBeacons, 3, false)
 
-int Leader_GetNeededLeaderVoteCount()
-{
-	int iOnlinePlayers = 0;
-
-	for (int i = 0; i < gpGlobals->maxClients; i++)
-	{
-		ZEPlayer* pPlayer = g_playerManager->GetPlayer(i);
-
-		if (pPlayer && !pPlayer->IsFakeClient())
-			iOnlinePlayers++;
-	}
-
-	return (int)(iOnlinePlayers * g_flLeaderVoteRatio) + 1;
-}
-
 bool Leader_SetNewLeader(ZEPlayer* zpLeader, std::string strColor = "")
 {
 	CCSPlayerController* pLeader = CCSPlayerController::FromSlot(zpLeader->GetPlayerSlot());
@@ -587,7 +572,7 @@ CON_COMMAND_CHAT(vl, "<name> - Vote for a player to become a leader")
 	}
 
 	int iLeaderVoteCount = pPlayerTarget->GetLeaderVoteCount();
-	int iNeededLeaderVoteCount = Leader_GetNeededLeaderVoteCount();
+	int iNeededLeaderVoteCount = (int)(g_playerManager->GetOnlinePlayerCount(false) * g_flLeaderVoteRatio) + 1;;
 
 	pPlayer->SetLeaderVoteTime(gpGlobals->curtime);
 

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -741,9 +741,9 @@ bool CMapVoteSystem::LoadMapList()
 		CMapInfo map = m_vecMapList[i];
 
 		if (map.GetWorkshopId() == 0)
-			ConMsg("Map %d is %s, which is %s. MinPlayers: %llu MaxPlayers: %llu Cooldown: %d\n", i, map.GetName(), map.IsEnabled() ? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
+			ConMsg("Map %d is %s, which is %s. MinPlayers: %d MaxPlayers: %d Cooldown: %d\n", i, map.GetName(), map.IsEnabled() ? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
 		else
-			ConMsg("Map %d is %s with workshop id %llu, which is %s. MinPlayers: %llu MaxPlayers: %llu Cooldown: %d\n", i, map.GetName(), map.GetWorkshopId(), map.IsEnabled()? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
+			ConMsg("Map %d is %s with workshop id %llu, which is %s. MinPlayers: %d MaxPlayers: %d Cooldown: %d\n", i, map.GetName(), map.GetWorkshopId(), map.IsEnabled()? "enabled" : "disabled", map.GetMinPlayers(), map.GetMaxPlayers(), map.GetBaseCooldown());
 	}
 
 	m_bMapListLoaded = true;

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -49,7 +49,7 @@ CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current
 
 	if (g_pMapVoteSystem->GetDownloadQueueSize() != 0)
 	{
-		Message("Please wait for current map downloads to finish before loading map list again\n");
+		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Please wait for current map downloads to finish before loading map list again.");
 		return;
 	}
 
@@ -67,7 +67,7 @@ CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current
 		V_snprintf(sChangeMapCmd, sizeof(sChangeMapCmd), "map %s", g_pMapVoteSystem->GetCurrentMap());
 
 	g_pEngineServer2->ServerCommand(sChangeMapCmd);
-	Message("Map list reloaded\n");
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Map list reloaded!");
 }
 
 CON_COMMAND_F(cs2f_vote_maps_cooldown, "Default number of maps to wait until a map can be voted / nominated again i.e. cooldown.", FCVAR_LINKED_CONCOMMAND | FCVAR_SPONLY)
@@ -454,19 +454,24 @@ void CMapVoteSystem::FinishVote()
 	if (iNextMapVoteIndex < 0) iNextMapVoteIndex = -1;
 	g_pGameRules->m_nEndMatchMapVoteWinner = iNextMapVoteIndex;
 	int iWinningMap = g_pGameRules->m_nEndMatchMapGroupVoteOptions[iNextMapVoteIndex];
+	char buffer[256];
+
 	if (bIsNextMapVoted) {
-		ClientPrintAll(HUD_PRINTTALK, "The vote has ended. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
+		V_snprintf(buffer, sizeof(buffer), "The vote has ended. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
 	}
 	else if (bIsNextMapForced) {
-		ClientPrintAll(HUD_PRINTTALK, "The vote was overriden. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
+		V_snprintf(buffer, sizeof(buffer), "The vote was overriden. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
 	}
 	else {
-		ClientPrintAll(HUD_PRINTTALK, "No map was chosen. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
+		V_snprintf(buffer, sizeof(buffer), "No map was chosen. \x06%s\x01 will be the next map!\n", GetMapName(iWinningMap));
 	}
+
+	ClientPrintAll(HUD_PRINTTALK, buffer);
+	Message(buffer);
 
 	// Print vote result information: how many votes did each map get?
 	int arrMapVotes[10] = { 0 };
-	ClientPrintAll(HUD_PRINTCONSOLE, "Map vote result --- total votes per map:\n");
+	Message("Map vote result --- total votes per map:\n");
 	for (int i = 0; i < gpGlobals->maxClients; i++) {
 		auto pController = CCSPlayerController::FromSlot(i);
 		int iPlayerVotedIndex = m_arrPlayerVotes[i];
@@ -477,7 +482,7 @@ void CMapVoteSystem::FinishVote()
 	for (int i = 0; i < 10; i++) {
 		int iMapIndex = g_pGameRules->m_nEndMatchMapGroupVoteOptions[i];
 		const char* sIsWinner = (i == iNextMapVoteIndex) ? "(WINNER)" : "";
-		ClientPrintAll(HUD_PRINTCONSOLE, "- %s got %d votes\n", GetMapName(iMapIndex), arrMapVotes[i]);
+		Message("- %s got %d votes\n", GetMapName(iMapIndex), arrMapVotes[i]);
 	}
 
 	// Put the map on cooldown as we transition to the next map if map index is valid, also decrease cooldown remaining for others

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -208,6 +208,24 @@ CON_COMMAND_CHAT(nomlist, "- List the list of nominations")
 	}
 }
 
+CON_COMMAND_CHAT(mapcooldowns, "- List the maps currently in cooldown")
+{
+	if (!g_bVoteManagerEnable)
+		return;
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "The list of maps in cooldown will be shown in console.");
+	ClientPrint(player, HUD_PRINTCONSOLE, "The list of maps in cooldown is:");
+	int iMapCount = g_pMapVoteSystem->GetMapListSize();
+	for (int iMapIndex = 0; iMapIndex < iMapCount; iMapIndex++) {
+		int iCooldown = g_pMapVoteSystem->GetCooldownMap(iMapIndex);
+		if (iCooldown > 0 && g_pMapVoteSystem->GetMapEnabledStatus(iMapIndex))
+		{
+			const char* sMapName = g_pMapVoteSystem->GetMapName(iMapIndex);
+			ClientPrint(player, HUD_PRINTCONSOLE, "- %s (%d maps remaining)", sMapName, iCooldown);
+		}
+	}
+}
+
 GAME_EVENT_F(cs_win_panel_match)
 {
 	if (g_bVoteManagerEnable && !g_pMapVoteSystem->IsVoteOngoing())

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -42,8 +42,6 @@ extern CIdleSystem* g_pIdleSystem;
 
 CMapVoteSystem* g_pMapVoteSystem = nullptr;
 
-int MapVote_GetOnlinePlayers();
-
 CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current map on completion", ADMFLAG_ROOT)
 {
 	if (!g_bVoteManagerEnable)
@@ -180,9 +178,9 @@ CON_COMMAND_CHAT_FLAGS(nominate, "[mapname] - Nominate a map (empty to clear nom
 					ClientPrint(player, HUD_PRINTCONSOLE, "- %s - Cooldown: %d", name, cooldown);
 				else if (mapIndex == g_pMapVoteSystem->GetCurrentMapIndex())
 					ClientPrint(player, HUD_PRINTCONSOLE, "- %s - Current Map", name);
-				else if (MapVote_GetOnlinePlayers() < minPlayers)
+				else if (g_playerManager->GetOnlinePlayerCount(false) < minPlayers)
 					ClientPrint(player, HUD_PRINTCONSOLE, "- %s - Minimum Players: %d", name, minPlayers);
-				else if (MapVote_GetOnlinePlayers() > maxPlayers)
+				else if (g_playerManager->GetOnlinePlayerCount(false) > maxPlayers)
 					ClientPrint(player, HUD_PRINTCONSOLE, "- %s - Maximum Players: %d", name, maxPlayers);
 				else
 					ClientPrint(player, HUD_PRINTCONSOLE, "- %s", name);
@@ -253,28 +251,13 @@ GAME_EVENT_F(endmatch_mapvote_selecting_map)
 		g_pMapVoteSystem->FinishVote();
 }
 
-int MapVote_GetOnlinePlayers()
-{
-	int iOnlinePlayers = 0;
-	for (int i = 0; i < gpGlobals->maxClients; i++)
-	{
-		ZEPlayer* pPlayer = g_playerManager->GetPlayer(i);
-
-		if (pPlayer && !pPlayer->IsFakeClient())
-		{
-			iOnlinePlayers++;
-		}
-	}
-	return iOnlinePlayers;
-}
-
 bool CMapVoteSystem::IsMapIndexEnabled(int iMapIndex)
 {
 	if (iMapIndex >= m_vecMapList.Count() || iMapIndex < 0) return false;
 	if (GetCooldownMap(iMapIndex) > 0 || GetCurrentMapIndex() == iMapIndex) return false;
 	if (!m_vecMapList[iMapIndex].IsEnabled()) return false;
 
-	int iOnlinePlayers = MapVote_GetOnlinePlayers();
+	int iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
 	bool bMeetsMaxPlayers = iOnlinePlayers <= m_vecMapList[iMapIndex].GetMaxPlayers();
 	bool bMeetsMinPlayers = iOnlinePlayers >= m_vecMapList[iMapIndex].GetMinPlayers();
 	return bMeetsMaxPlayers && bMeetsMinPlayers;

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -806,3 +806,28 @@ bool CMapVoteSystem::WriteMapCooldownsToFile()
 
 	return true;
 }
+
+void CMapVoteSystem::ClearInvalidNominations()
+{
+	if (!g_bVoteManagerEnable || m_bIsVoteOngoing)
+		return;
+
+	for (int i = 0; i < gpGlobals->maxClients; i++) {
+		int iNominatedMapIndex = m_arrPlayerNominations[i];
+
+		// Ignore unset nominations (negative index)
+		if (iNominatedMapIndex < 0)
+			continue;
+
+		// Check if nominated index still meets criteria for nomination
+		if (!IsMapIndexEnabled(iNominatedMapIndex))
+		{
+			ClearPlayerInfo(i);
+			CCSPlayerController* pPlayer = CCSPlayerController::FromSlot(i);
+			if (!pPlayer)
+				continue;
+
+			ClientPrint(pPlayer, HUD_PRINTTALK, CHAT_PREFIX "Your nomination for \x06%s \x01has been removed because the player count requirements are no longer met.", GetMapName(iNominatedMapIndex));
+		}
+	}
+}

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -149,6 +149,7 @@ CON_COMMAND_CHAT_FLAGS(nominate, "[mapname] - Nominate a map (empty to clear nom
 			break;
 		case NominationReturnCodes::NOMINATION_RESET:
 			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Your nomination was reset.");
+			g_pMapVoteSystem->ClearPlayerInfo(player->GetPlayerSlot());
 			break;
 		case NominationReturnCodes::NOMINATION_RESET_FAILED:
 		{

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -667,9 +667,9 @@ bool CMapVoteSystem::LoadMapList()
 		const char *pszName = pKey->GetName();
 		uint64 iWorkshopId = pKey->GetUint64("workshop_id");
 		bool bIsEnabled = pKey->GetBool("enabled", true);
+		int iMinPlayers = pKey->GetInt("minPlayers", 0);
+		int iMaxPlayers = pKey->GetInt("maxPlayers", 64);
 		int iBaseCooldown = pKey->GetInt("cooldown");
-		int iMinPlayers = pKey->GetInt("MinPlayers", 0);
-		int iMaxPlayers = pKey->GetInt("MaxPlayers", 64);
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 
 		if (iWorkshopId != 0)

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -72,6 +72,21 @@ CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current
 	Message("Map list reloaded\n");
 }
 
+CON_COMMAND_F(cs2f_vote_maps_cooldown, "Default number of maps to wait until a map can be voted / nominated again i.e. cooldown.", FCVAR_LINKED_CONCOMMAND | FCVAR_SPONLY)
+{
+	if (!g_pMapVoteSystem) {
+		Message("The map vote subsystem is not enabled.\n");
+		return;
+	}
+
+	if (args.ArgC() < 2)
+		Message("%s %d\n", args[0], g_pMapVoteSystem->GetDefaultMapCooldown());
+	else {
+		int iCurrentCooldown = g_pMapVoteSystem->GetDefaultMapCooldown();
+		g_pMapVoteSystem->SetDefaultMapCooldown(V_StringToInt32(args[1], iCurrentCooldown));
+	}
+}
+
 CON_COMMAND_F(cs2f_vote_max_nominations, "Number of nominations to include per vote, out of a maximum of 10.", FCVAR_LINKED_CONCOMMAND | FCVAR_SPONLY)
 {
 	if (!g_pMapVoteSystem) {
@@ -698,7 +713,7 @@ bool CMapVoteSystem::LoadMapList()
 		bool bIsEnabled = pKey->GetBool("enabled", true);
 		int iMinPlayers = pKey->GetInt("min_players", 0);
 		int iMaxPlayers = pKey->GetInt("max_players", 64);
-		int iBaseCooldown = pKey->GetInt("cooldown");
+		int iBaseCooldown = pKey->GetInt("cooldown", m_iDefaultMapCooldown);
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 
 		if (iWorkshopId != 0)

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -678,8 +678,8 @@ bool CMapVoteSystem::LoadMapList()
 		const char *pszName = pKey->GetName();
 		uint64 iWorkshopId = pKey->GetUint64("workshop_id");
 		bool bIsEnabled = pKey->GetBool("enabled", true);
-		int iMinPlayers = pKey->GetInt("minPlayers", 0);
-		int iMaxPlayers = pKey->GetInt("maxPlayers", 64);
+		int iMinPlayers = pKey->GetInt("min_players", 0);
+		int iMaxPlayers = pKey->GetInt("max_players", 64);
 		int iBaseCooldown = pKey->GetInt("cooldown");
 		int iCurrentCooldown = pKVcooldowns->GetInt(pszName, 0);
 

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -159,6 +159,9 @@ CON_COMMAND_CHAT_FLAGS(nominate, "[mapname] - Nominate a map (empty to clear nom
 
 			for (int i = 0; i < g_pMapVoteSystem->GetMapListSize(); i++)
 			{
+				if (!g_pMapVoteSystem->GetMapEnabledStatus(i))
+					continue;
+
 				MapIndexPair map;
 				map.name = g_pMapVoteSystem->GetMapName(i);
 				map.index = i;

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -687,7 +687,7 @@ bool CMapVoteSystem::LoadMapList()
 	// Load map cooldowns from file
 	KeyValues* pKVcooldowns = new KeyValues("cooldowns");
 	KeyValues::AutoDelete autoDeleteKVcooldowns(pKVcooldowns);
-	const char *pszCooldownFilePath = "addons/cs2fixes/configs/cooldowns.cfg";
+	const char *pszCooldownFilePath = "addons/cs2fixes/data/cooldowns.txt";
 	if (!pKVcooldowns->LoadFromFile(g_pFullFileSystem, pszCooldownFilePath)) {
 		Message("Failed to load cooldown file at %s - resetting all cooldowns to 0\n", pszCooldownFilePath);
 	}
@@ -774,7 +774,7 @@ bool CMapVoteSystem::WriteMapCooldownsToFile()
 	KeyValues* pKV = new KeyValues("cooldowns");
 	KeyValues::AutoDelete autoDelete(pKV);
 
-	const char *pszPath = "addons/cs2fixes/configs/cooldowns.cfg";
+	const char *pszPath = "addons/cs2fixes/data/cooldowns.txt";
 
 	FOR_EACH_VEC(m_vecMapList, i)
 	{

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -134,6 +134,7 @@ public:
     bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
     int GetDefaultMapCooldown() { return m_iDefaultMapCooldown; }
     void SetDefaultMapCooldown(int iMapCooldown) { m_iDefaultMapCooldown = iMapCooldown; }
+    void ClearInvalidNominations();
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -47,13 +47,13 @@ namespace NominationReturnCodes
 class CMapInfo
 {
 public:
-    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown)
+    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown, int iCurrentCooldown)
     {
         V_strcpy(m_pszName, pszName);
         m_iWorkshopId = iWorkshopId;
         m_bIsEnabled = bIsEnabled;
         m_iBaseCooldown = iBaseCooldown;
-        m_iCurrentCooldown = 0;
+        m_iCurrentCooldown = iCurrentCooldown;
     }
 
     const char* GetName() { return (const char*)m_pszName; };
@@ -126,6 +126,7 @@ private:
     int WinningMapIndex();
     bool UpdateWinningMap();
     void GetNominatedMapsForVote(CUtlVector<int>& vecChosenNominatedMaps);
+    bool WriteMapCooldownsToFile();
 
     STEAM_GAMESERVER_CALLBACK_MANUAL(CMapVoteSystem, OnMapDownloaded, DownloadItemResult_t, m_CallbackDownloadItemResult);
     CUtlQueue<PublishedFileId_t> m_DownloadQueue;

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -132,6 +132,8 @@ public:
     int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
     int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
     bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
+    int GetDefaultMapCooldown() { return m_iDefaultMapCooldown; }
+    void SetDefaultMapCooldown(int iMapCooldown) { m_iDefaultMapCooldown = iMapCooldown; }
 
 private:
     int WinningMapIndex();
@@ -145,6 +147,7 @@ private:
     CUtlVector<CMapInfo> m_vecMapList;
     int m_arrPlayerNominations[MAXPLAYERS];
     int m_iForcedNextMapIndex = -1;
+    int m_iDefaultMapCooldown = 10;
     int m_iMaxNominatedMaps = 10;
     int m_iRandomWinnerShift = 0;
     int m_arrPlayerVotes[MAXPLAYERS];

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -82,9 +82,8 @@ private:
 typedef struct
 {
     const char* name;
-    int cooldown;
-    int mapIndex;
-} MapCooldownStruct;
+    int index;
+} MapIndexPair;
 
 
 class CMapVoteSystem
@@ -130,6 +129,8 @@ public:
     int GetDownloadQueueSize() { return m_DownloadQueue.Count(); }
     int GetCurrentMapIndex() { return m_iCurrentMapIndex; }
     void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
+    int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
+    int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -131,6 +131,7 @@ public:
     void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
     int GetMapMinPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMinPlayers(); }
     int GetMapMaxPlayers(int iMapIndex) { return m_vecMapList[iMapIndex].GetMaxPlayers(); }
+    bool GetMapEnabledStatus(int iMapIndex) { return m_vecMapList[iMapIndex].IsEnabled(); }
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -77,7 +77,8 @@ typedef struct
 {
     const char* name;
     int cooldown;
-} MapCooldownPair;
+    int mapIndex;
+} MapCooldownStruct;
 
 
 class CMapVoteSystem
@@ -99,7 +100,7 @@ public:
     int GetMapIndexFromSubstring(const char* sMapSubstring);
     int GetCooldownMap(int iMapIndex) { return m_vecMapList[iMapIndex].GetCooldown(); };
     void PutMapOnCooldown(int iMapIndex) { m_vecMapList[iMapIndex].ResetCooldownToBase(); };
-    void PutMapOnCooldownAndDecrement(int iMapIndex);
+    void DecrementAllMapCooldowns();
     void SetMaxNominatedMaps(int iMaxNominatedMaps) { m_iMaxNominatedMaps = iMaxNominatedMaps; };
     int GetMaxNominatedMaps() { return m_iMaxNominatedMaps; };
     int AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
@@ -121,6 +122,8 @@ public:
     uint64 GetCurrentWorkshopMap() { return m_iCurrentWorkshopMap; }
     const char* GetCurrentMap() { return m_strCurrentMap.c_str(); }
     int GetDownloadQueueSize() { return m_DownloadQueue.Count(); }
+    int GetCurrentMapIndex() { return m_iCurrentMapIndex; }
+    void SetCurrentMapIndex(int iMapIndex) { m_iCurrentMapIndex = iMapIndex; }
 
 private:
     int WinningMapIndex();
@@ -137,6 +140,7 @@ private:
     int m_iMaxNominatedMaps = 10;
     int m_iRandomWinnerShift = 0;
     int m_arrPlayerVotes[MAXPLAYERS];
+    int m_iCurrentMapIndex;
     bool m_bIsVoteOngoing = false;
     bool m_bMapListLoaded = false;
     bool m_bIntermissionStarted = false;

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -26,6 +26,7 @@
 #include "steam/steam_api_common.h"
 #include "steam/isteamugc.h"
 #include <string>
+#include <vector>
 
 
 // Nomination constants, used as return codes for nomination commands
@@ -38,12 +39,13 @@ namespace NominationReturnCodes
     static const int NOMINATION_RESET = -102;
     static const int NOMINATION_RESET_FAILED = -103;
     static const int MAP_NOT_FOUND = -104;
-    static const int MAP_DISABLED = -105;
-    static const int MAP_CURRENT = -106;
-    static const int MAP_COOLDOWN = -107;
-    static const int MAP_MINPLAYERS = -108;
-    static const int MAP_MAXPLAYERS = -109;
-    static const int MAP_NOMINATED = -110;
+    static const int MAP_MULTIPLE = -105;
+    static const int MAP_DISABLED = -106;
+    static const int MAP_CURRENT = -107;
+    static const int MAP_COOLDOWN = -108;
+    static const int MAP_MINPLAYERS = -109;
+    static const int MAP_MAXPLAYERS = -110;
+    static const int MAP_NOMINATED = -111;
 }
 #endif
 
@@ -106,16 +108,17 @@ public:
     void StartVote();
     void FinishVote();
     bool RegisterPlayerVote(CPlayerSlot iPlayerSlot, int iVoteOption);
-    int GetMapIndexFromSubstring(const char* sMapSubstring);
+    std::vector<int> GetMapIndexesFromSubstring(const char* sMapSubstring);
+    int GetMapIndexFromString(const char* sMapString);
     int GetCooldownMap(int iMapIndex) { return m_vecMapList[iMapIndex].GetCooldown(); };
     void PutMapOnCooldown(int iMapIndex) { m_vecMapList[iMapIndex].ResetCooldownToBase(); };
     void DecrementAllMapCooldowns();
     void SetMaxNominatedMaps(int iMaxNominatedMaps) { m_iMaxNominatedMaps = iMaxNominatedMaps; };
     int GetMaxNominatedMaps() { return m_iMaxNominatedMaps; };
-    std::pair<int, int> AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
+    std::pair<int, std::vector<int>> AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
     bool IsMapIndexEnabled(int iMapIndex);
     int GetTotalNominations(int iMapIndex);
-    int ForceNextMap(const char* sMapSubstring);
+    std::pair<int, std::vector<int>> ForceNextMap(const char* sMapSubstring);
     int GetMapListSize() { return m_vecMapList.Count(); };
     const char* GetMapName(int iMapIndex) { return m_vecMapList[iMapIndex].GetName(); };
     uint64 GetMapWorkshopId(int iMapIndex) { return m_vecMapList[iMapIndex].GetWorkshopId(); };

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -34,12 +34,16 @@
 namespace NominationReturnCodes
 {
     static const int VOTE_STARTED = -100;
-    static const int INVALID_INPUT = -101;
-    static const int MAP_NOT_FOUND = -102;
-    static const int INVALID_MAP = -103;
-    static const int NOMINATION_DISABLED = -104;
-    static const int NOMINATION_RESET = -105;
-    static const int NOMINATION_RESET_FAILED = -106;
+    static const int NOMINATION_DISABLED = -101;
+    static const int NOMINATION_RESET = -102;
+    static const int NOMINATION_RESET_FAILED = -103;
+    static const int MAP_NOT_FOUND = -104;
+    static const int MAP_DISABLED = -105;
+    static const int MAP_CURRENT = -106;
+    static const int MAP_COOLDOWN = -107;
+    static const int MAP_MINPLAYERS = -108;
+    static const int MAP_MAXPLAYERS = -109;
+    static const int MAP_NOMINATED = -110;
 }
 #endif
 
@@ -108,7 +112,7 @@ public:
     void DecrementAllMapCooldowns();
     void SetMaxNominatedMaps(int iMaxNominatedMaps) { m_iMaxNominatedMaps = iMaxNominatedMaps; };
     int GetMaxNominatedMaps() { return m_iMaxNominatedMaps; };
-    int AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
+    std::pair<int, int> AddMapNomination(CPlayerSlot iPlayerSlot, const char* sMapSubstring);
     bool IsMapIndexEnabled(int iMapIndex);
     int GetTotalNominations(int iMapIndex);
     int ForceNextMap(const char* sMapSubstring);

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -135,6 +135,7 @@ public:
     int GetDefaultMapCooldown() { return m_iDefaultMapCooldown; }
     void SetDefaultMapCooldown(int iMapCooldown) { m_iDefaultMapCooldown = iMapCooldown; }
     void ClearInvalidNominations();
+    int GetForcedNextMap() { return m_iForcedNextMapIndex; }
 
 private:
     int WinningMapIndex();

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -47,13 +47,15 @@ namespace NominationReturnCodes
 class CMapInfo
 {
 public:
-    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iBaseCooldown, int iCurrentCooldown)
+    CMapInfo(const char* pszName, uint64 iWorkshopId, bool bIsEnabled, int iMinPlayers, int iMaxPlayers, int iBaseCooldown, int iCurrentCooldown)
     {
         V_strcpy(m_pszName, pszName);
         m_iWorkshopId = iWorkshopId;
         m_bIsEnabled = bIsEnabled;
         m_iBaseCooldown = iBaseCooldown;
         m_iCurrentCooldown = iCurrentCooldown;
+        m_iMinPlayers = iMinPlayers;
+        m_iMaxPlayers = iMaxPlayers;
     }
 
     const char* GetName() { return (const char*)m_pszName; };
@@ -63,11 +65,15 @@ public:
     int GetCooldown() { return m_iCurrentCooldown; };
     void ResetCooldownToBase() { m_iCurrentCooldown = m_iBaseCooldown; };
     void DecrementCooldown() { m_iCurrentCooldown = MAX(0, (m_iCurrentCooldown - 1)); }
+    int GetMinPlayers() { return m_iMinPlayers; };
+    int GetMaxPlayers() { return m_iMaxPlayers; };
 
 private:
     char m_pszName[64];
     uint64 m_iWorkshopId;
     bool m_bIsEnabled;
+    int m_iMinPlayers;
+    int m_iMaxPlayers;
     int m_iBaseCooldown;
     int m_iCurrentCooldown;
 };

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -43,6 +43,7 @@ extern IVEngineServer2 *g_pEngineServer2;
 extern CGameEntitySystem *g_pEntitySystem;
 extern CGlobalVars *gpGlobals;
 extern IGameEventSystem* g_gameEventSystem;
+extern CUtlVector<CServerSideClient*>* GetClientList();
 
 static int g_iAdminImmunityTargetting = 0;
 static bool g_bEnableMapSteamIds = false;
@@ -1595,4 +1596,19 @@ void CPlayerManager::ResetPlayerFlags(int slot)
 	SetPlayerSilenceSound(slot, false);
 	SetPlayerStopDecals(slot, true);
 	SetPlayerNoShake(slot, false);
+}
+
+int CPlayerManager::GetOnlinePlayerCount(bool bCountBots)
+{
+	int iOnlinePlayers = 0;
+
+	for (int i = 0; i < GetClientList()->Count(); i++)
+	{
+		CServerSideClient* pClient = (*GetClientList())[i];
+
+		if (pClient && pClient->GetSignonState() >= SIGNONSTATE_CONNECTED && (bCountBots || !pClient->IsFakeClient()))
+			iOnlinePlayers++;
+	}
+
+	return iOnlinePlayers;
 }

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -610,6 +610,7 @@ bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid, const char
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
+	g_pMapVoteSystem->ClearInvalidNominations();
 	
 	return true;
 }
@@ -627,6 +628,7 @@ void CPlayerManager::OnClientDisconnect(CPlayerSlot slot)
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
+	g_pMapVoteSystem->ClearInvalidNominations();
 
 	g_pPanoramaVoteHandler->RemovePlayerFromVote(slot.Get());
 }

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -397,6 +397,7 @@ public:
 	bool IsPlayerUsingNoShake(int slot) { return m_nUsingNoShake & ((uint64)1 << slot); }
 
 	void UpdatePlayerStates();
+	int GetOnlinePlayerCount(bool bCountBots);
 
 	STEAM_GAMESERVER_CALLBACK_MANUAL(CPlayerManager, OnValidateAuthTicket, ValidateAuthTicketResponse_t, m_CallbackValidateAuthTicketResponse);
 

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -159,7 +159,7 @@ public:
 		m_bVotedRTV = false;
 		m_bVotedExtend = false;
 		m_bIsInfected = false;
-		m_flRTVVoteTime = 0;
+		m_flRTVVoteTime = -60.0f;
 		m_flExtendVoteTime = 0;
 		m_iFloodTokens = 0;
 		m_flLastTalkTime = 0;

--- a/src/votemanager.cpp
+++ b/src/votemanager.cpp
@@ -279,7 +279,7 @@ CON_COMMAND_CHAT(rtv, "- Vote to end the current map sooner")
 		g_RTVState = ERTVState::POST_RTV_SUCCESSFULL;
 		g_ExtendState = EExtendState::POST_RTV;
 		// CONVAR_TODO
-		g_pEngineServer2->ServerCommand("mp_timelimit 1");
+		g_pEngineServer2->ServerCommand("mp_timelimit 0.01");
 
 		if (g_bRTVEndRound)
 		{

--- a/src/votemanager.cpp
+++ b/src/votemanager.cpp
@@ -167,22 +167,7 @@ int GetCurrentRTVCount()
 
 int GetNeededRTVCount()
 {
-	int iOnlinePlayers = 0.0f;
-	int iVoteCount = 0;
-
-	for (int i = 0; i < gpGlobals->maxClients; i++)
-	{
-		ZEPlayer* pPlayer = g_playerManager->GetPlayer(i);
-
-		if (pPlayer && !pPlayer->IsFakeClient())
-		{
-			iOnlinePlayers++;
-			if (pPlayer->GetRTVVote())
-				iVoteCount++;
-		}
-	}
-
-	return (int)(iOnlinePlayers * g_flRTVSucceedRatio) + 1;
+	return (int)(g_playerManager->GetOnlinePlayerCount(false) * g_flRTVSucceedRatio) + 1;
 }
 
 int GetCurrentExtendCount()


### PR DESCRIPTION
- Added custom cooldowns to maps
- Added cooldown saving across server restarts/crashes
- Cooldowns are now triggered by map end
- Fixed first map not going on cooldown
- Added minimum and maximum player requirements to maps
- Added more details to unavailable maps in !nominate list
- Added a shared function for getting the player count
- Fixed nomination resetting not working
- Added changing map by ID with !map if admin already has console access, this still can't be fully allowed due to bad ID's triggering workshop download game crashes
- Stopped displaying disabled maps in !nominate list
- Fixed !setnextmap permanently breaking map votes
- Added better feedback/behaviour to !setnextmap
- Fixed RTV's not working for a bit when quickly enabled manually at map start
- Added more detailed error messages to !nominate
- Added multiple maps warning to !nominate, to fix discoverability of some maps with shared queries (e.g. "fapescape")
- Fixed another injection possibility in !map

Effectively "part 2" to #225, however there is still more to do, so hopefully part 3 will not also take half a year 😆.