### PR TITLE
Misc dev

### DIFF
--- a/gamedata/cs2fixes.games.txt
+++ b/gamedata/cs2fixes.games.txt
@@ -465,6 +465,11 @@
 				"windows"		"22"
 				"linux"			"23"
 			}
+			"CCSPlayer_WeaponServices::SelectItem"
+			{
+				"windows"		"24"
+				"linux"			"25"
+			}
 			"CCSGameRules_GoToIntermission"
 			{
 				"windows"		"128"

--- a/src/addresses.cpp
+++ b/src/addresses.cpp
@@ -40,6 +40,7 @@ bool addresses::Initialize(CGameConfig *g_GameConfig)
 	modules::vscript = new CModule(ROOTBIN, "vscript");
 	modules::networksystem = new CModule(ROOTBIN, "networksystem");
 	modules::vphysics2 = new CModule(ROOTBIN, "vphysics2");
+	modules::matchmaking = new CModule(GAMEBIN, "matchmaking");
 	modules::client = nullptr;
 
 	if (!CommandLine()->HasParm("-dedicated"))

--- a/src/addresses.h
+++ b/src/addresses.h
@@ -34,6 +34,7 @@ namespace modules
 	inline CModule *client;
 	inline CModule* networksystem;
 	inline CModule* vphysics2;
+	inline CModule* matchmaking;
 #ifdef _WIN32
 	inline CModule *hammer;
 #endif

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -606,7 +606,7 @@ CON_COMMAND_CHAT_FLAGS(map, "<mapname> - Change map", ADMFLAG_CHANGEMAP)
 
 		// Check if input is numeric (workshop ID)
 		// Not safe to expose to all admins until crashing on failed workshop addon downloads is fixed
-		if ((!player || player->GetZEPlayer()->IsAdminFlagSet(ADMFLAG_RCON)) && V_StringToUint64(pszMapName, 0) != 0)
+		if ((!player || player->GetZEPlayer()->IsAdminFlagSet(ADMFLAG_RCON)) && V_StringToUint64(pszMapName, 0, NULL, NULL, PARSING_FLAG_SKIP_WARNING) != 0)
 		{
 			sCommand = "host_workshop_map " + sMapName;
 		}

--- a/src/adminsystem.cpp
+++ b/src/adminsystem.cpp
@@ -688,28 +688,8 @@ CON_COMMAND_CHAT_FLAGS(extend, "<minutes> - Extend current map (negative value r
 
 	int iExtendTime = V_StringToInt32(args[1], 0);
 
-	ConVar* cvar = g_pCVar->GetConVar(g_pCVar->FindConVar("mp_timelimit"));
-
-	// CONVAR_TODO
-	// HACK: values is actually the cvar value itself, hence this ugly cast.
-	float flTimelimit = *(float *)&cvar->values;
-
-	if (gpGlobals->curtime - g_pGameRules->m_flGameStartTime > flTimelimit * 60)
-		flTimelimit = (gpGlobals->curtime - g_pGameRules->m_flGameStartTime) / 60.0f + iExtendTime;
-	else
-	{
-		if (flTimelimit == 1)
-			flTimelimit = 0;
-		flTimelimit += iExtendTime;
-	}
-
-	if (flTimelimit <= 0)
-		flTimelimit = 1;
-
-	// CONVAR_TODO
-	char buf[32];
-	V_snprintf(buf, sizeof(buf), "mp_timelimit %.6f", flTimelimit);
-	g_pEngineServer2->ServerCommand(buf);
+	// Call the votemanager extend function so the extend vote can be checked
+	ExtendMap(iExtendTime);
 
 	const char* pszCommandPlayerName = player ? player->GetPlayerName() : CONSOLE_NAME;
 

--- a/src/cs2_sdk/entity/cbaseplayerpawn.h
+++ b/src/cs2_sdk/entity/cbaseplayerpawn.h
@@ -39,7 +39,7 @@ public:
 	SCHEMA_FIELD(QAngle, v_angle)
 
 	// Drops any map-spawned weapons the pawn is holding
-	// NOTE: Currently very broken with map items (entities parented to weapons?) due to a game bug..? Needs further investigation/work
+	// NOTE: This doesn't predict correctly to the weapon holder! Looks very funky when testing, but not really an issue on live servers
 	void DropMapWeapons()
 	{
 		if (!m_pWeaponServices())

--- a/src/cs2_sdk/entity/services.h
+++ b/src/cs2_sdk/entity/services.h
@@ -142,6 +142,12 @@ public:
 		static int offset = g_GameConfig->GetOffset("CCSPlayer_WeaponServices::DropWeapon");
 		CALL_VIRTUAL(void, offset, this, pWeapon, pVecTarget, pVelocity);
 	}
+
+	void SelectItem(CBasePlayerWeapon* pWeapon, int unk1 = 0)
+	{
+		static int offset = g_GameConfig->GetOffset("CCSPlayer_WeaponServices::SelectItem");
+		CALL_VIRTUAL(void, offset, this, pWeapon, unk1);
+	}
 };
 
 class CCSPlayerController_InGameMoneyServices

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -865,11 +865,10 @@ void CS2Fixes::Hook_CheckTransmit(CCheckTransmitInfo **ppInfoList, int infoCount
 			if (!pController || pController->m_bIsHLTV || j == iPlayerSlot)
 				continue;
 
-			// Don't transmit other players' flashlights, except the one they're watching if in spec
+			// Don't transmit other players' flashlights
 			CBarnLight *pFlashLight = pController->IsConnected() ? g_playerManager->GetPlayer(j)->GetFlashLight() : nullptr;
 
-			if (!g_bFlashLightTransmitOthers && pFlashLight &&
-				!(pSelfController->GetPawnState() == STATE_OBSERVER_MODE && pSelfController->GetObserverTarget() == pController->GetPawn()))
+			if (!g_bFlashLightTransmitOthers && pFlashLight)
 			{
 				pInfo->m_pTransmitEntity->Clear(pFlashLight->entindex());
 			}

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -1009,9 +1009,9 @@ void CS2Fixes::Hook_PhysicsTouchShuffle(CUtlVector<TouchLinked_t>* pList, bool u
 
 	pList->Purge();
 
-	for (const auto link : touchingLinks)
+	for (const auto &link : touchingLinks)
 		pList->AddToTail(link);
-	for (const auto link : unTouchLinks)
+	for (const auto &link : unTouchLinks)
 		pList->AddToTail(link);
 }
 

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -173,6 +173,26 @@ GAME_EVENT_F(player_spawn)
 
 		return -1.0f;
 	});
+
+	// And this needs even more delay..? Don't even know if this is enough, bug can't be reproduced
+	new CTimer(0.1f, false, false, [hController]()
+	{
+		CCSPlayerController* pController = hController.Get();
+
+		if (!pController)
+			return -1.0f;
+
+		CBasePlayerPawn* pPawn = pController->GetPawn();
+
+		if (pPawn)
+		{
+			// Fix new haunted CS2 bug? https://www.reddit.com/r/cs2/comments/1glvg9s/thank_you_for_choosing_anubis_airlines/
+			// We've seen this several times across different maps at this point
+			pPawn->m_vecAbsVelocity = Vector(0, 0, 0);
+		}
+
+		return -1.0f;
+	});
 }
 
 static bool g_bEnableTopDefender = false;

--- a/src/gameconfig.cpp
+++ b/src/gameconfig.cpp
@@ -129,6 +129,8 @@ CModule **CGameConfig::GetModule(const char *name)
 		return &modules::tier0;
 	else if (strcmp(library, "networksystem") == 0)
 		return &modules::networksystem;
+	else if (strcmp(library, "matchmaking") == 0)
+		return &modules::matchmaking;
 #ifdef _WIN32
 	else if (strcmp(library, "hammer") == 0)
 		return &modules::hammer;

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -1305,7 +1305,7 @@ ETargetError CPlayerManager::GetPlayersFromString(CCSPlayerController* pPlayer, 
 		CBaseEntity* entTarget = nullptr;
 		entTarget = UTIL_FindPickerEntity(pPlayer);
 
-		if (!entTarget->IsPawn())
+		if (!entTarget || !entTarget->IsPawn())
 			return ETargetError::INVALID;
 
 		CCSPlayerController* pTarget = CCSPlayerController::FromPawn(static_cast<CCSPlayerPawn*>(entTarget));

--- a/src/votemanager.h
+++ b/src/votemanager.h
@@ -36,6 +36,7 @@ enum class EExtendState
 	IN_PROGRESS,
 	POST_EXTEND_COOLDOWN,
 	POST_EXTEND_NO_EXTENDS_LEFT,
+	POST_EXTEND_FAILED,
 	POST_LAST_ROUND_END,
 	POST_RTV,
 	NO_EXTENDS,
@@ -51,7 +52,6 @@ enum EExtendVoteMode
 
 extern ERTVState g_RTVState;
 extern EExtendState g_ExtendState;
-extern int g_iExtendsLeft;
 extern bool g_bVoteManagerEnable;
 
 void VoteManager_Init();

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -1881,7 +1881,7 @@ CON_COMMAND_CHAT(zclass, "<teamname/class name/number> - Find and select your Z:
 	FOR_EACH_VEC(vecClasses, i)
 	{
 		const char* sClassName = vecClasses[i]->szClassName.c_str();
-		bool bClassMatches = !V_stricmp(sClassName, args[1]) || (V_StringToInt32(args[1], -1) - 1) == i;
+		bool bClassMatches = !V_stricmp(sClassName, args[1]) || (V_StringToInt32(args[1], -1, NULL, NULL, PARSING_FLAG_SKIP_WARNING) - 1) == i;
 		std::shared_ptr<ZRClass> pClass = vecClasses[i];
 
 		if (bClassMatches)

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -739,6 +739,10 @@ bool CZRRegenTimer::Execute()
 	if (!pPawn || !pPawn->IsAlive())
 		return false;
 
+	// Do we even need to regen?
+	if (pPawn->m_iHealth() >= pPawn->m_iMaxHealth())
+		return true;
+
 	int iHealth = pPawn->m_iHealth() + m_iRegenAmount;
 	pPawn->m_iHealth = pPawn->m_iMaxHealth() < iHealth ? pPawn->m_iMaxHealth() : iHealth;
 	return true;

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -860,7 +860,7 @@ void ZRWeaponConfig::LoadWeaponConfig()
 		bool bEnabled = pKey->GetBool("enabled", false);
 		float flKnockback = pKey->GetFloat("knockback", 1.0f);
 		Message("%s knockback: %f\n", pszWeaponName, flKnockback);
-		ZRWeapon *weapon = new ZRWeapon;
+		std::shared_ptr<ZRWeapon> weapon = std::make_shared<ZRWeapon>();
 		if (!bEnabled)
 			continue;
 
@@ -872,7 +872,7 @@ void ZRWeaponConfig::LoadWeaponConfig()
 	return;
 }
 
-ZRWeapon* ZRWeaponConfig::FindWeapon(const char *pszWeaponName)
+std::shared_ptr<ZRWeapon> ZRWeaponConfig::FindWeapon(const char *pszWeaponName)
 {
 	uint16 index = m_WeaponMap.Find(hash_32_fnv1a_const(pszWeaponName));
 	if (m_WeaponMap.IsValidIndex(index))
@@ -1083,7 +1083,7 @@ void ZR_OnPlayerSpawn(CCSPlayerController* pController)
 
 void ZR_ApplyKnockback(CCSPlayerPawn *pHuman, CCSPlayerPawn *pVictim, int iDamage, const char *szWeapon, int hitgroup, float classknockback)
 {
-	ZRWeapon *pWeapon = g_pZRWeaponConfig->FindWeapon(szWeapon);
+	std::shared_ptr<ZRWeapon> pWeapon = g_pZRWeaponConfig->FindWeapon(szWeapon);
 	std::shared_ptr<ZRHitgroup> pHitgroup = g_pZRHitgroupConfig->FindHitgroupIndex(hitgroup);
 	// player shouldn't be able to pick up that weapon in the first place, but just in case
 	if (!pWeapon)
@@ -1102,7 +1102,7 @@ void ZR_ApplyKnockback(CCSPlayerPawn *pHuman, CCSPlayerPawn *pVictim, int iDamag
 
 void ZR_ApplyKnockbackExplosion(CBaseEntity *pProjectile, CCSPlayerPawn *pVictim, int iDamage, bool bMolotov)
 {
-	ZRWeapon *pWeapon = g_pZRWeaponConfig->FindWeapon(pProjectile->GetClassname());
+	std::shared_ptr<ZRWeapon> pWeapon = g_pZRWeaponConfig->FindWeapon(pProjectile->GetClassname());
 	if (!pWeapon)
 		return;
 	float flWeaponKnockbackScale = pWeapon->flKnockback;

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -1135,14 +1135,29 @@ void ZR_FakePlayerDeath(CCSPlayerController *pAttackerController, CCSPlayerContr
 void ZR_StripAndGiveKnife(CCSPlayerPawn *pPawn)
 {
 	CCSPlayer_ItemServices *pItemServices = pPawn->m_pItemServices();
+	CCSPlayer_WeaponServices* pWeaponServices = pPawn->m_pWeaponServices();
 
 	// it can sometimes be null when player joined on the very first round? 
-	if (!pItemServices)
+	if (!pItemServices || !pWeaponServices)
 		return;
 
 	pPawn->DropMapWeapons();
 	pItemServices->StripPlayerWeapons(true);
 	pItemServices->GiveNamedItem("weapon_knife");
+
+	CUtlVector<CHandle<CBasePlayerWeapon>>* weapons = pWeaponServices->m_hMyWeapons();
+
+	FOR_EACH_VEC(*weapons, i)
+	{
+		CBasePlayerWeapon* pWeapon = (*weapons)[i].Get();
+
+		if (pWeapon && pWeapon->GetWeaponVData()->m_GearSlot() == GEAR_SLOT_KNIFE)
+		{
+			// Normally this isn't necessary, but there's a small window if infected right after throwing a grenade where this is needed
+			pWeaponServices->SelectItem(pWeapon);
+			break;
+		}
+	}
 }
 
 void ZR_Cure(CCSPlayerController *pTargetController)

--- a/src/zombiereborn.h
+++ b/src/zombiereborn.h
@@ -259,9 +259,9 @@ public:
 		m_WeaponMap.SetLessFunc(DefLessFunc(uint32));
 	};
 	void LoadWeaponConfig();
-	ZRWeapon* FindWeapon(const char *pszWeaponName);
+	std::shared_ptr<ZRWeapon> FindWeapon(const char *pszWeaponName);
 private:
-	CUtlMap<uint32, ZRWeapon*> m_WeaponMap;
+	CUtlMap<uint32, std::shared_ptr<ZRWeapon>> m_WeaponMap;
 };
 
 


### PR DESCRIPTION
- Fixed a compiler warning/optimized code in player physics shuffle
- Silenced string conversion warnings in cases where non-numeric input is expected
- Fixed bugged active weapon if a grenade was thrown right before infection
- Fixed knife skin not always matching loadout if different knives were equipped for each team
- Fixed revived humans not having armour, obeys `mp_free_armor`
- Added re-strip on revives, prevents ZM items lingering
- Fixed zombie regen clamping health values above max health (fixes paramina ZM item HP, still recommended to set `max_health` to enable higher regen)
- Stopped transmitting flashlights in spec, this was causing random rare "missing client entity" client crashes since some CS2 update
- Added matchmaking bin to available gamedata bins
- Switched to smart pointers for ZR weapon configs, should no longer leak memory
- Added possible workaround for CS2 randomly spawning players with mega-velocity ([example](https://www.reddit.com/r/cs2/comments/1glvg9s/thank_you_for_choosing_anubis_airlines/)), unknown if it works
- Fixed a crash with `@aim` targeting
- Updated extend tracking, so total extend count is now shown in !extendsleft
- Removed !addextend, since it's redundant with !adminve existing (or adjusting `cs2f_extends`)