### PR TITLE
Fix/workarounds for 2024-12-19 CS2 update

### DIFF
--- a/src/leader.cpp
+++ b/src/leader.cpp
@@ -268,6 +268,9 @@ void Leader_RemoveLeaderVisuals(CCSPlayerPawn* pPawn)
 
 bool Leader_CreateDefendMarker(ZEPlayer* pPlayer, Color clrTint, int iDuration)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return false;
+
 	CCSPlayerController* pController = CCSPlayerController::FromSlot(pPlayer->GetPlayerSlot());
 	CCSPlayerPawn* pPawn = (CCSPlayerPawn*)pController->GetPawn();
 
@@ -402,6 +405,9 @@ void Leader_OnRoundStart(IGameEvent* pEvent)
 // revisit this later with a TempEnt implementation
 void Leader_BulletImpact(IGameEvent* pEvent)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	ZEPlayer* pPlayer = g_playerManager->GetPlayer(pEvent->GetPlayerSlot("userid"));
 
 	if (!pPlayer || pPlayer->GetTracerColor().a() < 255)

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -176,6 +176,9 @@ FAKE_STRING_CVAR(cs2f_flashlight_attachment, "Which attachment to parent a flash
 
 void ZEPlayer::SpawnFlashLight()
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	if (GetFlashLight())
 		return;
 
@@ -279,6 +282,9 @@ void PrecacheBeaconParticle(IEntityResourceManifest* pResourceManifest)
 
 void ZEPlayer::StartBeacon(Color color, ZEPlayerHandle hGiver /* = 0*/)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	SetBeaconColor(color);
 
 	CCSPlayerController* pPlayer = CCSPlayerController::FromSlot(m_slot);
@@ -360,6 +366,9 @@ void ZEPlayer::EndBeacon()
 // iDuration being non-positive only kills off active marks.
 void ZEPlayer::CreateMark(float fDuration, Vector vecOrigin)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	if (m_handleMark && m_handleMark.IsValid())
 	{
 		UTIL_AddEntityIOEvent(m_handleMark.Get(), "DestroyImmediately", nullptr, nullptr, "", 0);
@@ -422,6 +431,9 @@ void ZEPlayer::PurgeLeaderVotes()
 
 void ZEPlayer::StartGlow(Color color, int duration)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	SetGlowColor(color);
 	CCSPlayerController* pController = CCSPlayerController::FromSlot(m_slot);
 	CCSPlayerPawn* pPawn = (CCSPlayerPawn*)pController->GetPawn();

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -156,6 +156,9 @@ void ZR_Precache(IEntityResourceManifest* pResourceManifest)
 
 void ZR_CreateOverlay(const char* pszOverlayParticlePath, float flAlpha, float flRadius, float flLifeTime, Color clrTint, const char* pszMaterialOverride)
 {
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	return;
+
 	CEnvParticleGlow* particle = CreateEntityByName<CEnvParticleGlow>("env_particle_glow");
 
 	CEntityKeyValues* pKeyValues = new CEntityKeyValues();
@@ -1012,10 +1015,13 @@ void ZR_OnRoundPrestart(IGameEvent* pEvent)
 void SetupRespawnToggler()
 {
 	CBaseEntity* relay = CreateEntityByName("logic_relay");
-	CEntityKeyValues* pKeyValues = new CEntityKeyValues();
+	// CEntityKeyValues is broken after 2024-12-19 CS2 update, awaiting SDK update
+	//CEntityKeyValues* pKeyValues = new CEntityKeyValues();
 
-	pKeyValues->SetString("targetname", "zr_toggle_respawn");
-	relay->DispatchSpawn(pKeyValues);
+	//pKeyValues->SetString("targetname", "zr_toggle_respawn");
+	//relay->DispatchSpawn(pKeyValues);
+	relay->DispatchSpawn();
+	relay->SetName("zr_toggle_respawn");
 	g_hRespawnToggler = relay->GetHandle();
 }
 


### PR DESCRIPTION
Usually we would wait for upstream SDK fix, but this is currently expected to be days out.

Recommended to run `cs2f_flashlight_enable 0` & `cs2f_leader_enable 0` with this, but it won't crash if you don't.