### PR TITLE
Feat: add classic spawn warning message

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -93,6 +93,7 @@ zr_knockback_scale				5.0		// Global knockback scale
 zr_ztele_max_distance 			150.0	// Maximum distance players are allowed to move after starting ztele
 zr_ztele_allow_humans 			0		// Whether to allow humans to use ztele
 zr_infect_spawn_type			1		// Type of Mother Zombies Spawn [0 = MZ spawn where they stand, 1 = MZ get teleported back to spawn on being picked]
+zr_infect_spawn_warning			1		// Whether to warn players of zombies spawning between humans
 zr_infect_spawn_time_min		15		// Minimum time in which Mother Zombies should be picked, after round start
 zr_infect_spawn_time_max		15		// Maximum time in which Mother Zombies should be picked, after round start
 zr_infect_spawn_mz_ratio		7		// Ratio of all Players to Mother Zombies to be spawned at round start

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -76,6 +76,7 @@ CConVar<float> g_cvarMaxZteleDistance("zr_ztele_max_distance", FCVAR_NONE, "Maxi
 CConVar<bool> g_cvarZteleHuman("zr_ztele_allow_humans", FCVAR_NONE, "Whether to allow humans to use ztele", false);
 CConVar<float> g_cvarKnockbackScale("zr_knockback_scale", FCVAR_NONE, "Global knockback scale", 5.0f);
 CConVar<int> g_cvarInfectSpawnType("zr_infect_spawn_type", FCVAR_NONE, "Type of Mother Zombies Spawn [0 = MZ spawn where they stand, 1 = MZ get teleported back to spawn on being picked]", (int)EZRSpawnType::RESPAWN, true, 0, true, 1);
+CConVar<bool> g_cvarInfectSpawnWarning("zr_infect_spawn_warning", FCVAR_NONE, "Whether to warn players of zombies spawning between humans", false);
 CConVar<int> g_cvarInfectSpawnTimeMin("zr_infect_spawn_time_min", FCVAR_NONE, "Minimum time in which Mother Zombies should be picked, after round start", 15, true, 0, false, 0);
 CConVar<int> g_cvarInfectSpawnTimeMax("zr_infect_spawn_time_max", FCVAR_NONE, "Maximum time in which Mother Zombies should be picked, after round start", 15, true, 1, false, 0);
 CConVar<int> g_cvarInfectSpawnMZRatio("zr_infect_spawn_mz_ratio", FCVAR_NONE, "Ratio of all Players to Mother Zombies to be spawned at round start", 7, true, 1, true, 64);
@@ -1013,6 +1014,8 @@ void SetupCTeams()
 void ZR_OnRoundStart(IGameEvent* pEvent)
 {
 	ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "The game is \x05Humans vs. Zombies\x01, the goal for zombies is to infect all humans by knifing them.");
+	if (g_cvarInfectSpawnWarning.Get())
+		ClientPrintAll(HUD_PRINTTALK, ZR_PREFIX "Classic spawns enabled! Zombies will be \x07spawning between humans\x01!");
 	SetupRespawnToggler();
 	CZRRegenTimer::RemoveAllTimers();
 


### PR DESCRIPTION
This is a continuation of my unfinished pull request #166 . I've added a separate convar for warning messages and removed the warning message from the infection timer in chat. Open to ideas on changes.