### PR TITLE
Feat: show damage

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -428,6 +428,32 @@ CON_COMMAND_CHAT(noshake, "- toggle noshake")
 	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have %s noshake.", bSet ? "enabled" : "disabled");
 }
 
+CConVar<bool> g_cvarEnableShowDamage("cs2f_showdamage_enable", FCVAR_NONE, "Whether to enable ShowDamage", false);
+CON_COMMAND_CHAT(showdamage, "- Toggle show damage")
+{
+	if (!g_cvarEnableShowDamage.Get())
+		return;
+
+	if (!player)
+	{
+		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command from the server console.");
+		return;
+	}
+
+	ZEPlayer* pZEPlayer = player->GetZEPlayer();
+
+	// Something has to really go wrong for this to happen
+	if (!pZEPlayer)
+	{
+		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
+		return;
+	}
+
+	bool bSet = !pZEPlayer->GetShowDamageStatus();
+	pZEPlayer->SetShowDamageStatus(bSet);
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "You have%s\1 show damage.", bSet ? "\4 enabled" : "\2 disabled");
+}
+
 CConVar<bool> g_cvarEnableHide("cs2f_hide_enable", FCVAR_NONE, "Whether to enable hide (WARNING: randomly crashes clients since 2023-12-13 CS2 update)", false);
 CConVar<int> g_cvarDefaultHideDistance("cs2f_hide_distance_default", FCVAR_NONE, "The default distance for hide", 250, true, 0, false, 0);
 CConVar<int> g_cvarMaxHideDistance("cs2f_hide_distance_max", FCVAR_NONE, "The max distance for hide", 2000, true, 0, false, 0);

--- a/src/commands.h
+++ b/src/commands.h
@@ -43,6 +43,7 @@ extern CConVar<bool> g_cvarEnableHide;
 extern CConVar<bool> g_cvarEnableStopSound;
 extern CConVar<bool> g_cvarEnableNoShake;
 extern CConVar<float> g_cvarMaxShakeAmp;
+extern CConVar<bool> g_cvarEnableShowDamage;
 
 void ClientPrintAll(int destination, const char* msg, ...);
 void ClientPrint(CCSPlayerController* player, int destination, const char* msg, ...);

--- a/src/events.cpp
+++ b/src/events.cpp
@@ -198,7 +198,7 @@ CConVar<bool> g_cvarEnableTopDefender("cs2f_topdefender_enable", FCVAR_NONE, "Wh
 
 GAME_EVENT_F(player_hurt)
 {
-	if (!g_cvarEnableTopDefender.Get())
+	if (!g_cvarEnableTopDefender.Get() && !g_cvarEnableShowDamage.Get())
 		return;
 
 	CCSPlayerController* pAttacker = (CCSPlayerController*)pEvent->GetPlayerController("attacker");
@@ -213,8 +213,17 @@ GAME_EVENT_F(player_hurt)
 	if (!pPlayer)
 		return;
 
-	pPlayer->SetTotalDamage(pPlayer->GetTotalDamage() + pEvent->GetInt("dmg_health"));
-	pPlayer->SetTotalHits(pPlayer->GetTotalHits() + 1);
+	int iDamage = pEvent->GetInt("dmg_health");
+	if (g_cvarEnableShowDamage.Get() && pPlayer->GetShowDamageStatus())
+	{
+		ClientPrint(pAttacker, HUD_PRINTCENTER, "You did %i damage to %s\nHealth remaining: %i", iDamage, pVictim->GetPlayerName(), pEvent->GetInt("health"));
+	}
+
+	if (g_cvarEnableTopDefender.Get())
+	{
+		pPlayer->SetTotalDamage(pPlayer->GetTotalDamage() + iDamage);
+		pPlayer->SetTotalHits(pPlayer->GetTotalHits() + 1);
+	}
 }
 
 GAME_EVENT_F(player_death)

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -742,6 +742,12 @@ void ZEPlayer::SetEntwatchHudSize(float flSize)
 		pText->m_flFontSize = m_flEntwatchHudSize;
 }
 
+void ZEPlayer::SetShowDamageStatus(bool status)
+{
+	m_bShowDamage = status;
+	g_pUserPreferencesSystem->SetPreferenceInt(m_slot.Get(), SHOW_DAMAGE_PREF_KEY_NAME, m_bShowDamage ? 1 : 0);
+}
+
 void CPlayerManager::OnBotConnected(CPlayerSlot slot)
 {
 	m_vecPlayers[slot.Get()] = new ZEPlayer(slot, true);

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -50,6 +50,7 @@
 #define SOUND_STATUS_PREF_KEY_NAME "sound_status"
 #define NO_SHAKE_PREF_KEY_NAME "no_shake"
 #define BUTTON_WATCH_PREF_KEY_NAME "button_watch"
+#define SHOW_DAMAGE_PREF_KEY_NAME "show_damage"
 #define INVALID_ZEPLAYERHANDLE_INDEX 0u
 
 static uint32 iZEPlayerHandleSerial = 0u; // this should actually be 3 bytes large, but no way enough players join in servers lifespan for this to be an issue
@@ -193,6 +194,7 @@ public:
 		m_flEntwatchHudX = -7.5f;
 		m_flEntwatchHudY = -2.0f;
 		m_flEntwatchHudSize = 60.0f;
+		m_bShowDamage = true;
 	}
 
 	~ZEPlayer()
@@ -262,6 +264,7 @@ public:
 	void SetEntwatchHudColor(Color colorHud);
 	void SetEntwatchHudPos(float x, float y);
 	void SetEntwatchHudSize(float flSize);
+	void SetShowDamageStatus(bool status);
 
 	uint64 GetAdminFlags() { return m_iAdminFlags; }
 	int GetAdminImmunity() { return m_iAdminImmunity; }
@@ -311,6 +314,7 @@ public:
 	float GetEntwatchHudX() { return m_flEntwatchHudX; }
 	float GetEntwatchHudY() { return m_flEntwatchHudY; }
 	float GetEntwatchHudSize() { return m_flEntwatchHudSize; }
+	bool GetShowDamageStatus() { return m_bShowDamage; }
 
 	void OnSpawn();
 	void OnAuthenticated();
@@ -382,6 +386,7 @@ private:
 	float m_flEntwatchHudX;
 	float m_flEntwatchHudY;
 	float m_flEntwatchHudSize;
+	bool m_bShowDamage;
 };
 
 class CPlayerManager

--- a/src/user_preferences.cpp
+++ b/src/user_preferences.cpp
@@ -116,6 +116,7 @@ void CUserPreferencesSystem::OnPutPreferences(int iSlot)
 	bool bHideDecals = (bool)GetPreferenceInt(iSlot, DECAL_PREF_KEY_NAME, 1);
 	bool bNoShake = (bool)GetPreferenceInt(iSlot, NO_SHAKE_PREF_KEY_NAME, 0);
 	int iButtonWatchMode = GetPreferenceInt(iSlot, BUTTON_WATCH_PREF_KEY_NAME, 0);
+	bool bShowDamage = (bool)GetPreferenceInt(iSlot, SHOW_DAMAGE_PREF_KEY_NAME, 1);
 
 	// EntWatch
 	int iEntwatchMode = GetPreferenceInt(iSlot, EW_PREF_HUD_MODE, 0);
@@ -136,6 +137,7 @@ void CUserPreferencesSystem::OnPutPreferences(int iSlot)
 	player->SetHideDistance(iHideDistance);
 	for (int i = 0; i < iButtonWatchMode; i++)
 		player->CycleButtonWatch();
+	player->SetShowDamageStatus(bShowDamage);
 
 	// Set EntWatch
 	player->SetEntwatchHudMode(iEntwatchMode);


### PR DESCRIPTION
Adds `!showdamage` functionality from CS:GO. Commands and functionality were tested, but client preferences were not thoroughly tested.