### PR TITLE
update admin chat to match old sourcemod behaviour

### DIFF
--- a/configs/admins.jsonc.example
+++ b/configs/admins.jsonc.example
@@ -51,7 +51,7 @@
 		// 
 		//  // If at least 1 group is added above, these are all optional fields.
 		//	"flags": "abcdefg", // Permission flags. Combines with any flags defined in user's groups
-		//	"immunity": "1" // Non-negative value. Takes highest value from here or any of user's groups
+		//	"immunity": 1 // Non-negative value. Takes highest value from here or any of user's groups
 		//}
 	}
 }

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -532,6 +532,7 @@ void CS2Fixes::Hook_DispatchConCommand(ConCommandRef cmdHandle, const CCommandCo
 		auto pController = CCSPlayerController::FromSlot(iCommandPlayerSlot);
 		bool bGagged = pController && pController->GetZEPlayer()->IsGagged();
 		bool bFlooding = pController && pController->GetZEPlayer()->IsFlooding();
+		bool bIsAdmin = pController && pController->GetZEPlayer()->IsAdminFlagSet(ADMFLAG_GENERIC);
 		bool bAdminChat = bTeamSay && *args[1] == '@';
 		bool bSilent = *args[1] == '/' || bAdminChat;
 		bool bCommand = *args[1] == '!' || *args[1] == '/';
@@ -575,10 +576,8 @@ void CS2Fixes::Hook_DispatchConCommand(ConCommandRef cmdHandle, const CCommandCo
 				if (!pPlayer)
 					continue;
 
-				if (pPlayer->IsAdminFlagSet(ADMFLAG_GENERIC))
-					ClientPrint(CCSPlayerController::FromSlot(i), HUD_PRINTTALK, " \4(ADMINS) %s:\1 %s", pController->GetPlayerName(), pszMessage);
-				else if (i == iCommandPlayerSlot.Get()) // Sender is not an admin
-					ClientPrint(pController, HUD_PRINTTALK, " \4(TO ADMINS) %s:\1 %s", pController->GetPlayerName(), pszMessage);
+				if (i == iCommandPlayerSlot.Get() || pPlayer->IsAdminFlagSet(ADMFLAG_GENERIC))
+					ClientPrint(CCSPlayerController::FromSlot(i), HUD_PRINTTALK, " \4(%sADMINS) %s:\6 %s", bIsAdmin ? "" : "TO ", pController->GetPlayerName(), pszMessage);
 			}
 		}
 


### PR DESCRIPTION
change players (non-admins) message to be printed as (TO ADMINS) instead of (ADMINS) to online admins
and misc template change