### PR TITLE
Fix gcc complain about missing std::optional

### DIFF
--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -29,6 +29,7 @@
 #include <playerslot.h>
 #include <string>
 #include <vector>
+#include <optional>
 
 class CMap;
 using ordered_json = nlohmann::ordered_json;


### PR DESCRIPTION
Fix this:

<img width="2295" height="287" alt="Screenshot 2025-09-10 121234" src="https://github.com/user-attachments/assets/28c1e538-2fa1-4653-965f-770df4817dc8" />
