### PR TITLE
Entwatch update

### DIFF
--- a/src/cs2_sdk/entity/cbaseplayerpawn.h
+++ b/src/cs2_sdk/entity/cbaseplayerpawn.h
@@ -62,8 +62,19 @@ public:
 			}
 		}
 
+		Vector pos = GetEyePosition();
 		for (CBasePlayerWeapon* pWeapon : vecWeaponsToDrop)
+		{
 			m_pWeaponServices()->DropWeapon(pWeapon);
+
+			CHandle<CBasePlayerWeapon> hWep = pWeapon->GetHandle();
+			CTimer::Create(0.0, TIMERFLAG_MAP | TIMERFLAG_ROUND, [hWep, pos] {
+				CBasePlayerWeapon* pWep = hWep.Get();
+				if (pWep)
+					pWep->Teleport(&pos, nullptr, nullptr);
+				return -1.0f;
+			});
+		}
 	}
 
 	void CommitSuicide(bool bExplode, bool bForce)

--- a/src/entwatch.h
+++ b/src/entwatch.h
@@ -178,7 +178,7 @@ public:
 		sClantag(""),
 		bHasThisClantag(false),
 		iTeamNum(CS_TEAM_NONE),
-		bShouldGlow(false){};
+		bShouldGlow(false) {};
 	bool RegisterHandler(CBaseEntity* pEnt, int iHandlerTemplateNum);
 	bool RemoveHandler(CBaseEntity* pEnt);
 	int FindHandlerByEntIndex(int indexToFind);
@@ -205,13 +205,19 @@ struct ETransferInfo
 	float flTime;							// The time when the command was initiated
 };
 
+struct EActiveTransfer
+{
+	CHandle<CCSPlayerController> hReceiver;
+	CHandle<CBasePlayerWeapon> hWeapon;
+	float flTime;
+};
+
 class CEWHandler
 {
 public:
 	CEWHandler()
 	{
 		bConfigLoaded = false;
-		m_bHudTicking = false;
 
 		iBaseBtnUseHookId = -1;
 		iPhysboxUseHookId = -1;
@@ -278,9 +284,10 @@ public:
 	int iRotBtnUseHookId;
 	int iMomRotBtnUseHookId;
 
-	bool m_bHudTicking;
+	std::weak_ptr<CTimer> m_pHudTimer;
 
-	std::map<int, std::shared_ptr<ETransferInfo>> mapTransfers; // Any etransfers that target multiple items
+	std::map<int, std::shared_ptr<ETransferInfo>> mapTransfers;		  // Any etransfers that target multiple items
+	std::vector<std::shared_ptr<EActiveTransfer>> vecActiveTransfers; // Active transfers where only the receiver can pickup the weapon
 };
 
 extern CEWHandler* g_pEWHandler;


### PR DESCRIPTION
- Clantags show item cd/uses
- Transferred items can only be picked up by the target for 1s
- Dropped map weapons get teleported to player eye position to stop them falling through floors