### PR TITLE
feat: Added !hidemode command

### DIFF
--- a/src/commands.cpp
+++ b/src/commands.cpp
@@ -434,6 +434,7 @@ CConVar<bool> g_cvarEnableHide("cs2f_hide_enable", FCVAR_NONE, "Whether to enabl
 CConVar<bool> g_cvarHideWeapons("cs2f_hide_weapons", FCVAR_NONE, "Whether to hide weapons along with their holders", false);
 CConVar<int> g_cvarDefaultHideDistance("cs2f_hide_distance_default", FCVAR_NONE, "The default distance for hide", 250, true, 0, false, 0);
 CConVar<int> g_cvarMaxHideDistance("cs2f_hide_distance_max", FCVAR_NONE, "The max distance for hide", 2000, true, 0, false, 0);
+CConVar<bool> g_cvarEnableHideMode("cs2f_hide_mode_enable", FCVAR_NONE, "Whether to enable hide mode command", false);
 
 CON_COMMAND_CHAT(hide, "<distance> - Hide nearby players")
 {
@@ -479,6 +480,64 @@ CON_COMMAND_CHAT(hide, "<distance> - Hide nearby players")
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Hiding players is now disabled.");
 	else
 		ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Now hiding players within \x06%i units\x01.", distance);
+}
+CON_COMMAND_CHAT(hidemode, "[mode] - Cycle or set hide mode: 0 (Normal), 1 (Include Items), 2 (Hide Everyone)")
+{
+	// Silently return so the command is completely hidden
+	if (!g_cvarEnableHide.Get() || !g_cvarEnableHideMode.Get())
+		return;
+
+	if (!player)
+	{
+		ClientPrint(player, HUD_PRINTCONSOLE, CHAT_PREFIX "You cannot use this command from the server console.");
+		return;
+	}
+
+	ZEPlayer* pZEPlayer = player->GetZEPlayer();
+
+	// Something has to really go wrong for this to happen
+	if (!pZEPlayer)
+	{
+		Warning("%s Tried to access a null ZEPlayer!!\n", player->GetPlayerName());
+		return;
+	}
+
+	int iMode;
+	if(args.ArgC() < 2)
+	{
+		pZEPlayer->CycleHideMode();
+		iMode = pZEPlayer->GetHideMode();
+	}
+	else
+	{
+		iMode = V_StringToInt32(args[1], -1);
+		if (iMode != HIDE_MODE_NORMAL && iMode != HIDE_MODE_ITEMS && iMode != HIDE_MODE_ALL)
+		{
+			ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Invalid hide mode. Valid modes are: %i (Normal), %i (Include Items), %i (Hide Everyone)", HIDE_MODE_NORMAL, HIDE_MODE_ITEMS, HIDE_MODE_ALL);
+			return;
+		}
+		if (iMode == pZEPlayer->GetHideMode()) {
+			iMode = HIDE_MODE_NORMAL;
+		}
+
+		pZEPlayer->SetHideMode(iMode);
+	}
+
+	const char* desc;
+	switch (iMode)
+	{
+		case HIDE_MODE_NORMAL:
+			desc = "Normal";
+			break;
+		case HIDE_MODE_ITEMS:
+			desc = "Include Items";
+			break;
+		case HIDE_MODE_ALL:
+			desc = "Hide Everyone";
+			break;
+	}
+
+	ClientPrint(player, HUD_PRINTTALK, CHAT_PREFIX "Hide mode is: %s.", desc);
 }
 
 void PrintHelp(const CCommand& args, CCSPlayerController* player)

--- a/src/commands.h
+++ b/src/commands.h
@@ -34,6 +34,7 @@ extern CConVar<bool> g_cvarEnableNoShake;
 extern CConVar<float> g_cvarMaxShakeAmp;
 extern CConVar<bool> g_cvarEnableHide;
 extern CConVar<bool> g_cvarHideWeapons;
+extern CConVar<bool> g_cvarEnableHideMode;
 
 #define CMDFLAG_NONE (0)
 #define CMDFLAG_NOHELP (1 << 0) // Don't show in !help menu

--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -991,9 +991,13 @@ void CS2Fixes::Hook_CheckTransmit(CCheckTransmitInfo** ppInfoList, int infoCount
 			if (!pPawn)
 				continue;
 
-			// Do not hide leaders or item holders to other players
+			// Hide players according to hide distance and hide mode settings
 			ZEPlayer* pOtherZEPlayer = g_playerManager->GetPlayer(j);
-			if (pSelfZEPlayer->ShouldBlockTransmit(j) && pOtherZEPlayer && !pOtherZEPlayer->IsLeader() && g_pEWHandler->FindItemInstanceByOwner(j, false, 0) == -1)
+			int iHideMode = pSelfZEPlayer->GetHideMode();
+			
+			if (pSelfZEPlayer->ShouldBlockTransmit(j) && pOtherZEPlayer
+				&& (iHideMode == HIDE_MODE_ALL 
+					|| (!pOtherZEPlayer->IsLeader() && (iHideMode == HIDE_MODE_ITEMS || g_pEWHandler->FindItemInstanceByOwner(j, false, 0) == -1))))
 			{
 				pInfo->m_pTransmitEntity->Clear(pPawn->entindex());
 

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -163,6 +163,22 @@ void ZEPlayer::SetHideDistance(int distance)
 	g_pUserPreferencesSystem->SetPreferenceInt(m_slot.Get(), HIDE_DISTANCE_PREF_KEY_NAME, distance);
 }
 
+int ZEPlayer::GetHideMode()
+{
+	return g_pUserPreferencesSystem->GetPreferenceInt(m_slot.Get(), HIDE_MODE_PREF_KEY_NAME, HIDE_MODE_NORMAL);
+}
+
+void ZEPlayer::SetHideMode(int mode)
+{
+	g_pUserPreferencesSystem->SetPreferenceInt(m_slot.Get(), HIDE_MODE_PREF_KEY_NAME, mode);
+}
+
+void ZEPlayer::CycleHideMode()
+{
+	int iMode = (GetHideMode() + 1) % 3;
+	SetHideMode(iMode);
+}
+
 CConVar<bool> g_cvarFlashLightShadows("cs2f_flashlight_shadows", FCVAR_NONE, "Whether to enable flashlight shadows", true);
 CConVar<bool> g_cvarFlashLightTransmitOthers("cs2f_flashlight_transmit_others", FCVAR_NONE, "Whether to transmit other player's flashlights, recommended to have shadows off for this", false);
 CConVar<float> g_cvarFlashLightBrightness("cs2f_flashlight_brightness", FCVAR_NONE, "How bright should flashlights be", 1.0f);

--- a/src/playermanager.h
+++ b/src/playermanager.h
@@ -50,11 +50,16 @@ extern CConVar<CUtlString> g_cvarFlashLightAttachment;
 
 #define DECAL_PREF_KEY_NAME "hide_decals"
 #define HIDE_DISTANCE_PREF_KEY_NAME "hide_distance"
+#define HIDE_MODE_PREF_KEY_NAME "hide_mode"
 #define SOUND_STATUS_PREF_KEY_NAME "sound_status"
 #define NO_SHAKE_PREF_KEY_NAME "no_shake"
 #define BUTTON_WATCH_PREF_KEY_NAME "button_watch"
 #define ZSOUNDS_PREF_KEY_NAME "zsounds"
 #define INVALID_ZEPLAYERHANDLE_INDEX 0u
+
+#define HIDE_MODE_NORMAL 0
+#define HIDE_MODE_ITEMS 1
+#define HIDE_MODE_ALL 2
 
 static uint32 iZEPlayerHandleSerial = 0u; // this should actually be 3 bytes large, but no way enough players join in servers lifespan for this to be an issue
 
@@ -230,6 +235,8 @@ public:
 	void SetTransmit(int index, bool shouldTransmit) { shouldTransmit ? m_shouldTransmit.Set(index) : m_shouldTransmit.Clear(index); }
 	void ClearTransmit() { m_shouldTransmit.ClearAll(); }
 	void SetHideDistance(int distance);
+	void SetHideMode(int mode);
+	void CycleHideMode();
 	void SetTotalDamage(int damage) { m_iTotalDamage = damage; }
 	void SetTotalHits(int hits) { m_iTotalHits = hits; }
 	void SetTotalHeadshots(int headshots) { m_iTotalHeadshots = headshots; }
@@ -277,6 +284,7 @@ public:
 	bool IsEbanned() { return m_bEbanned; }
 	bool ShouldBlockTransmit(int index) { return m_shouldTransmit.Get(index); }
 	int GetHideDistance();
+	int GetHideMode();
 	CPlayerSlot GetPlayerSlot() { return m_slot; }
 	int GetTotalDamage() { return m_iTotalDamage; }
 	int GetTotalHits() { return m_iTotalHits; }

--- a/src/user_preferences.cpp
+++ b/src/user_preferences.cpp
@@ -106,6 +106,7 @@ bool CUserPreferencesSystem::PutPreferences(int iSlot, uint64 iSteamId, UserPref
 void CUserPreferencesSystem::OnPutPreferences(int iSlot)
 {
 	int iHideDistance = GetPreferenceInt(iSlot, HIDE_DISTANCE_PREF_KEY_NAME, 0);
+	int iHideMode = GetPreferenceInt(iSlot, HIDE_MODE_PREF_KEY_NAME, HIDE_MODE_NORMAL);
 	int iSoundStatus = GetPreferenceInt(iSlot, SOUND_STATUS_PREF_KEY_NAME, 1);
 	bool bStopSound = (bool)(iSoundStatus & 1);
 	bool bSilenceSound = (bool)(iSoundStatus & 2);
@@ -131,6 +132,7 @@ void CUserPreferencesSystem::OnPutPreferences(int iSlot)
 
 	ZEPlayer* player = g_playerManager->GetPlayer(CPlayerSlot(iSlot));
 	player->SetHideDistance(iHideDistance);
+	player->SetHideMode(iHideMode);
 	for (int i = 0; i < iButtonWatchMode; i++)
 		player->CycleButtonWatch();
 


### PR DESCRIPTION
Adds !hidemode command to allow players to hide item holders and even leaders.
Players can cycle or directly set the mode.
Using the command doesnt directly toggle hide state.
Functionality will help for lazer sections and maps with lots of items.

Issue: Just like when a player is glowed and it enters hide range and the glow stays on the last spot, the same happens with items as they seem to get stuck in the place until the hidden item holder is not within hiding distance anymore.