### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ CS2Fixes is a Metamod plugin with fixes and features aimed but not limited to zo
 - Download the [latest release package](https://github.com/Source2ZE/CS2Fixes/releases) for your OS
 - Extract the package contents into `game/csgo` on your server
 - Configure the plugin cvars as desired in `cfg/cs2fixes/cs2fixes.cfg`, many features are disabled by default
-- OPTIONAL: If you want to setup admins, rename `admins.cfg.example` to `admins.cfg` which can be found in `addons/cs2fixes/configs` and follow the instructions within to add admins
+- OPTIONAL: If you want to setup admins, rename `admins.jsonc.example` to `admins.jsonc` which can be found in `addons/cs2fixes/configs` and follow the instructions within to add admins
 
 ## Fixes and Features
 You can find the documentation of the fixes and features [here](../../wiki/Home).


### PR DESCRIPTION
Instructions for adding admins was still referring to the old keyvalues-based config instead of the updated jsonc file.