### PR TITLE
Don't SUPERCEDE jointeam for bots

### DIFF
--- a/src/cs2fixes.cpp
+++ b/src/cs2fixes.cpp
@@ -845,6 +845,13 @@ void CS2Fixes::Hook_ClientCommand(CPlayerSlot slot, const CCommand& args)
 
 	if (g_cvarEnableZR.Get() && slot != -1 && !V_strncmp(args.Arg(0), "jointeam", 8))
 	{
+		// Bots use jointeam to finish connecting. SUPERCEDE is evaluated here,
+		// so an early return in ZR_Hook_ClientCommand_JoinTeam still blocks it
+		// and leaves fill's new bots stuck in challenging (status id 65535).
+		CCSPlayerController* pController = CCSPlayerController::FromSlot(slot);
+		if (pController && pController->IsBot())
+			RETURN_META(MRES_IGNORED);
+
 		ZR_Hook_ClientCommand_JoinTeam(slot, args);
 		RETURN_META(MRES_SUPERCEDE);
 	}

--- a/src/zombiereborn.cpp
+++ b/src/zombiereborn.cpp
@@ -1587,6 +1587,10 @@ void ZR_Hook_ClientCommand_JoinTeam(CPlayerSlot slot, const CCommand& args)
 	if (!pController)
 		return;
 
+	// Engine jointeam is how bots finish connecting after bot_kick / quota refill.
+	if (pController->IsBot())
+		return;
+
 	CCSPlayerPawn* pPawn = (CCSPlayerPawn*)pController->GetPawn();
 	if (pPawn && pPawn->IsAlive())
 		pPawn->CommitSuicide(false, true);


### PR DESCRIPTION
When `zr_enable` is on, `Hook_ClientCommand` SUPERCEDEs every `jointeam`. That is correct for humans (ZR assigns teams), but bots use `jointeam` to finish connecting. After `bot_kick` / a `bot_quota` refill they then sit in `status` as `65535 [NoChan] challenging` and never spawn.

The ignore has to happen at the hook site. An early return inside `ZR_Hook_ClientCommand_JoinTeam` still falls through to `MRES_SUPERCEDE`.

Human `jointeam` is unchanged. Boot-time fill already works via `PutInServer` → `SpawnPlayer`; this only unblocks later quota refills.

If you run bots on ZR, set `bot_join_team ct` (or `t`). Default `any` can reopen the CT-force kick/re-add loop from #185 / Source2ZE/ZombieReborn#64.

`bot_quota 0` then `bot_quota 10` in the same map can still latch in the base game (#169). `bot_kick` then setting quota again is the path this fixes.

## Test
- `zr_enable 1`, `bot_join_team ct`, `bot_quota 10`, `bot_quota_mode fill`
- `bot_kick`, wait for refill
- `status` shows 10 real bots, not `65535` challenging ghosts
