### PR TITLE
Add low population features to Map Vote System

### DIFF
--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -98,6 +98,7 @@ cs2f_vote_maps_cooldown 		6.0		// Default number of hours until a map can be pla
 cs2f_vote_maps_cooldown_rng 	0.0		// Randomness range in both directions to apply to map cooldowns
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10
 cs2f_vote_max_maps 				10		// Number of total maps to include per vote, including nominations, out of a maximum of 10
+cs2f_vote_lowpop_max_count      10      // Maximum amount of players required to enable low population features in map vote system
 
 // User preferences settings
 cs2f_user_prefs_api				""		// User Preferences REST API endpoint

--- a/cfg/cs2fixes/cs2fixes.cfg
+++ b/cfg/cs2fixes/cs2fixes.cfg
@@ -98,7 +98,7 @@ cs2f_vote_maps_cooldown 		6.0		// Default number of hours until a map can be pla
 cs2f_vote_maps_cooldown_rng 	0.0		// Randomness range in both directions to apply to map cooldowns
 cs2f_vote_max_nominations 		10		// Number of nominations to include per vote, out of a maximum of 10
 cs2f_vote_max_maps 				10		// Number of total maps to include per vote, including nominations, out of a maximum of 10
-cs2f_vote_lowpop_max_count      10      // Maximum amount of players required to enable low population features in map vote system
+cs2f_vote_bypass_cd_max_count	0		// Maximum amount of players allowed to enable bypassing map cooldowns
 
 // User preferences settings
 cs2f_user_prefs_api				""		// User Preferences REST API endpoint

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -43,6 +43,7 @@ CConVar<float> g_cvarVoteMapsCooldown("cs2f_vote_maps_cooldown", FCVAR_NONE, "De
 CConVar<float> g_cvarVoteMapsCooldownRng("cs2f_vote_maps_cooldown_rng", FCVAR_NONE, "Randomness range in both directions to apply to map cooldowns", 0.0f);
 CConVar<int> g_cvarVoteMaxNominations("cs2f_vote_max_nominations", FCVAR_NONE, "Number of nominations to include per vote, out of a maximum of 10", 10, true, 0, true, 10);
 CConVar<int> g_cvarVoteMaxMaps("cs2f_vote_max_maps", FCVAR_NONE, "Number of total maps to include per vote, including nominations, out of a maximum of 10", 10, true, 2, true, 10);
+CConVar<int> g_cvarVoteLowPopMaxCount("cs2f_vote_lowpop_max_count", FCVAR_NONE, "Maximum amount of players required to enable low population features in map vote system", 10, true, 0, false, 0);
 
 CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current map on completion", ADMFLAG_ROOT)
 {
@@ -168,11 +169,13 @@ CON_COMMAND_CHAT(maplist, "- List the maps in the server")
 	g_pMapVoteSystem->PrintMapList(player);
 }
 
-bool CMap::IsAvailable()
+bool CMap::IsAvailable(int iOnlinePlayers)
 {
 	auto pThis = shared_from_this();
+	if (iOnlinePlayers == -1)
+		iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
 
-	if (GetCooldown()->IsOnCooldown())
+	if (GetCooldown()->IsOnCooldown() && iOnlinePlayers > g_cvarVoteLowPopMaxCount.Get())
 		return false;
 
 	if (*g_pMapVoteSystem->GetCurrentMap() == *pThis)
@@ -181,7 +184,6 @@ bool CMap::IsAvailable()
 	if (!IsEnabled())
 		return false;
 
-	int iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
 	bool bMeetsMaxPlayers = iOnlinePlayers <= GetMaxPlayers();
 	bool bMeetsMinPlayers = iOnlinePlayers >= GetMinPlayers();
 	return bMeetsMaxPlayers && bMeetsMinPlayers;
@@ -759,7 +761,7 @@ void CMapVoteSystem::AttemptNomination(CCSPlayerController* pController, const c
 			return;
 		}
 
-		if (pMap->GetCooldown()->IsOnCooldown())
+		if (pMap->GetCooldown()->IsOnCooldown() && iPlayerCount > g_cvarVoteLowPopMaxCount.Get())
 		{
 			ClientPrint(pController, HUD_PRINTTALK, CHAT_PREFIX "Cannot nominate \x06%s\x01 because it's on a %s cooldown.", pMap->GetName(), pMap->GetCooldownText(false).c_str());
 			return;
@@ -1108,10 +1110,15 @@ bool CMapVoteSystem::WriteMapCooldownsToFile()
 	return true;
 }
 
-void CMapVoteSystem::ClearInvalidNominations()
+void CMapVoteSystem::OnPlayerCountChange()
 {
 	if (!g_cvarVoteManagerEnable.Get() || m_bIsVoteOngoing || !GetGlobals())
 		return;
+
+	int iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
+
+	if (iOnlinePlayers > m_iSessionMaxPlayerCount)
+		m_iSessionMaxPlayerCount = iOnlinePlayers;
 
 	for (int i = 0; i < GetGlobals()->maxClients; i++)
 	{
@@ -1124,7 +1131,7 @@ void CMapVoteSystem::ClearInvalidNominations()
 		auto pMap = GetMapByIndex(iNominatedMapIndex);
 
 		// Check if nominated map still meets criteria for nomination
-		if (!pMap->IsAvailable())
+		if (!pMap->IsAvailable(iOnlinePlayers))
 		{
 			ClearPlayerInfo(i);
 			CCSPlayerController* pPlayer = CCSPlayerController::FromSlot(i);
@@ -1153,16 +1160,19 @@ void CMapVoteSystem::ApplyGameSettings(const char* pszMapName, uint64 iWorkshopI
 
 void CMapVoteSystem::OnLevelShutdown()
 {
-	// Put the map on cooldown as we transition to the next map
-	PutMapOnCooldown(GetCurrentMap()->GetName());
-
-	// Fully apply pending group cooldowns
-	for (std::shared_ptr<CCooldown> pCooldown : m_vecCooldowns)
+	if (m_iSessionMaxPlayerCount > g_cvarVoteLowPopMaxCount.Get())
 	{
-		if (pCooldown->GetPendingCooldown() > 0.0f)
+		// Put the map on cooldown as we transition to the next map
+		PutMapOnCooldown(GetCurrentMap()->GetName());
+
+		// Fully apply pending group cooldowns
+		for (std::shared_ptr<CCooldown> pCooldown : m_vecCooldowns)
 		{
-			PutMapOnCooldown(pCooldown->GetMapName(), pCooldown->GetPendingCooldown());
-			pCooldown->SetPendingCooldown(0.0f);
+			if (pCooldown->GetPendingCooldown() > 0.0f)
+			{
+				PutMapOnCooldown(pCooldown->GetMapName(), pCooldown->GetPendingCooldown());
+				pCooldown->SetPendingCooldown(0.0f);
+			}
 		}
 	}
 
@@ -1177,6 +1187,8 @@ void CMapVoteSystem::OnLevelShutdown()
 		if (m_timeMapListModified != std::filesystem::last_write_time(szPath))
 			ReloadMapList(false);
 	}
+
+	m_iSessionMaxPlayerCount = 0;
 }
 
 std::string CMapVoteSystem::ConvertFloatToString(float fValue, int precision)

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -43,7 +43,7 @@ CConVar<float> g_cvarVoteMapsCooldown("cs2f_vote_maps_cooldown", FCVAR_NONE, "De
 CConVar<float> g_cvarVoteMapsCooldownRng("cs2f_vote_maps_cooldown_rng", FCVAR_NONE, "Randomness range in both directions to apply to map cooldowns", 0.0f);
 CConVar<int> g_cvarVoteMaxNominations("cs2f_vote_max_nominations", FCVAR_NONE, "Number of nominations to include per vote, out of a maximum of 10", 10, true, 0, true, 10);
 CConVar<int> g_cvarVoteMaxMaps("cs2f_vote_max_maps", FCVAR_NONE, "Number of total maps to include per vote, including nominations, out of a maximum of 10", 10, true, 2, true, 10);
-CConVar<int> g_cvarVoteLowPopMaxCount("cs2f_vote_lowpop_max_count", FCVAR_NONE, "Maximum amount of players required to enable low population features in map vote system", 10, true, 0, false, 0);
+CConVar<int> g_cvarVoteBypassCooldownMaxCount("cs2f_vote_bypass_cd_max_count", FCVAR_NONE, "Maximum amount of players allowed to enable bypassing map cooldowns", 0, true, 0, false, 0);
 
 CON_COMMAND_CHAT_FLAGS(reload_map_list, "- Reload map list, also reloads current map on completion", ADMFLAG_ROOT)
 {
@@ -169,13 +169,11 @@ CON_COMMAND_CHAT(maplist, "- List the maps in the server")
 	g_pMapVoteSystem->PrintMapList(player);
 }
 
-bool CMap::IsAvailable(int iOnlinePlayers)
+bool CMap::IsAvailable()
 {
 	auto pThis = shared_from_this();
-	if (iOnlinePlayers == -1)
-		iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
 
-	if (GetCooldown()->IsOnCooldown() && iOnlinePlayers > g_cvarVoteLowPopMaxCount.Get())
+	if (GetCooldown()->IsOnCooldown())
 		return false;
 
 	if (*g_pMapVoteSystem->GetCurrentMap() == *pThis)
@@ -184,6 +182,7 @@ bool CMap::IsAvailable(int iOnlinePlayers)
 	if (!IsEnabled())
 		return false;
 
+	int iOnlinePlayers = g_playerManager->GetOnlinePlayerCount(false);
 	bool bMeetsMaxPlayers = iOnlinePlayers <= GetMaxPlayers();
 	bool bMeetsMinPlayers = iOnlinePlayers >= GetMinPlayers();
 	return bMeetsMaxPlayers && bMeetsMinPlayers;
@@ -761,7 +760,7 @@ void CMapVoteSystem::AttemptNomination(CCSPlayerController* pController, const c
 			return;
 		}
 
-		if (pMap->GetCooldown()->IsOnCooldown() && iPlayerCount > g_cvarVoteLowPopMaxCount.Get())
+		if (pMap->GetCooldown()->IsOnCooldown())
 		{
 			ClientPrint(pController, HUD_PRINTTALK, CHAT_PREFIX "Cannot nominate \x06%s\x01 because it's on a %s cooldown.", pMap->GetName(), pMap->GetCooldownText(false).c_str());
 			return;
@@ -1131,7 +1130,7 @@ void CMapVoteSystem::OnPlayerCountChange()
 		auto pMap = GetMapByIndex(iNominatedMapIndex);
 
 		// Check if nominated map still meets criteria for nomination
-		if (!pMap->IsAvailable(iOnlinePlayers))
+		if (!pMap->IsAvailable())
 		{
 			ClearPlayerInfo(i);
 			CCSPlayerController* pPlayer = CCSPlayerController::FromSlot(i);
@@ -1160,7 +1159,7 @@ void CMapVoteSystem::ApplyGameSettings(const char* pszMapName, uint64 iWorkshopI
 
 void CMapVoteSystem::OnLevelShutdown()
 {
-	if (m_iSessionMaxPlayerCount > g_cvarVoteLowPopMaxCount.Get())
+	if (m_iSessionMaxPlayerCount > g_cvarVoteBypassCooldownMaxCount.Get())
 	{
 		// Put the map on cooldown as we transition to the next map
 		PutMapOnCooldown(GetCurrentMap()->GetName());
@@ -1326,6 +1325,11 @@ std::shared_ptr<CCooldown> CMapVoteSystem::GetMapCooldown(const char* pszMapName
 	m_vecCooldowns.push_back(pCooldown);
 
 	return pCooldown;
+}
+
+bool CCooldown::IsOnCooldown()
+{
+	return GetCurrentCooldown() > 0.0f && g_playerManager->GetOnlinePlayerCount(false) > g_cvarVoteBypassCooldownMaxCount.Get();
 }
 
 float CCooldown::GetCurrentCooldown()

--- a/src/map_votes.cpp
+++ b/src/map_votes.cpp
@@ -1159,19 +1159,23 @@ void CMapVoteSystem::ApplyGameSettings(const char* pszMapName, uint64 iWorkshopI
 
 void CMapVoteSystem::OnLevelShutdown()
 {
-	if (m_iSessionMaxPlayerCount > g_cvarVoteBypassCooldownMaxCount.Get())
+	bool bApplyCooldowns = m_iSessionMaxPlayerCount > g_cvarVoteBypassCooldownMaxCount.Get();
+
+	if (bApplyCooldowns)
 	{
 		// Put the map on cooldown as we transition to the next map
 		PutMapOnCooldown(GetCurrentMap()->GetName());
+	}
 
-		// Fully apply pending group cooldowns
-		for (std::shared_ptr<CCooldown> pCooldown : m_vecCooldowns)
+	// Fully apply or discard pending group cooldowns
+	for (std::shared_ptr<CCooldown> pCooldown : m_vecCooldowns)
+	{
+		if (pCooldown->GetPendingCooldown() > 0.0f)
 		{
-			if (pCooldown->GetPendingCooldown() > 0.0f)
-			{
+			if (bApplyCooldowns)
 				PutMapOnCooldown(pCooldown->GetMapName(), pCooldown->GetPendingCooldown());
-				pCooldown->SetPendingCooldown(0.0f);
-			}
+
+			pCooldown->SetPendingCooldown(0.0f);
 		}
 	}
 

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -89,7 +89,7 @@ public:
 	std::vector<std::string> GetGroups() { return m_vecGroups; };
 	bool HasGroup(std::string strGroup) { return std::find(m_vecGroups.begin(), m_vecGroups.end(), strGroup) != m_vecGroups.end(); };
 
-	bool IsAvailable();
+	bool IsAvailable(int iOnlinePlayers = -1);
 	bool Load();
 	std::shared_ptr<CCooldown> GetCooldown();
 	std::string GetCooldownText(bool bPlural);
@@ -206,7 +206,7 @@ public:
 	std::shared_ptr<CMap> GetCurrentMap() { return m_pCurrentMap; }
 	void SetCurrentMap(std::shared_ptr<CMap> pCurrentMap) { m_pCurrentMap = pCurrentMap; }
 	int GetDownloadQueueSize() { return m_DownloadQueue.size(); }
-	void ClearInvalidNominations();
+	void OnPlayerCountChange();
 	std::shared_ptr<CMap> GetForcedNextMap() { return m_pForcedNextMap; }
 	void SetForcedNextMap(std::shared_ptr<CMap> pForcedNextMap) { m_pForcedNextMap = pForcedNextMap; }
 	std::unordered_map<int, int> GetNominatedMaps();
@@ -247,6 +247,7 @@ private:
 	std::weak_ptr<CTimer> m_pDownloadProgressTimer;
 	std::weak_ptr<CTimer> m_pRateLimitedDownloadTimer;
 	std::vector<std::shared_ptr<CMapSystemWorkshopDetailsQuery>> m_vecWorkshopDetailsQueries;
+	int m_iSessionMaxPlayerCount = 0;
 };
 
 extern CMapVoteSystem* g_pMapVoteSystem;

--- a/src/map_votes.h
+++ b/src/map_votes.h
@@ -50,8 +50,8 @@ public:
 	void SetTimeCooldown(time_t timeCooldown) { m_timeCooldown = timeCooldown; };
 	float GetPendingCooldown() { return m_fPendingCooldown; };
 	void SetPendingCooldown(float fPendingCooldown) { m_fPendingCooldown = fPendingCooldown; };
-	bool IsOnCooldown() { return GetCurrentCooldown() > 0.0f; }
 	bool IsPending() { return m_fPendingCooldown > 0.0f && m_fPendingCooldown == GetCurrentCooldown(); };
+	bool IsOnCooldown();
 	float GetCurrentCooldown();
 
 private:
@@ -89,7 +89,7 @@ public:
 	std::vector<std::string> GetGroups() { return m_vecGroups; };
 	bool HasGroup(std::string strGroup) { return std::find(m_vecGroups.begin(), m_vecGroups.end(), strGroup) != m_vecGroups.end(); };
 
-	bool IsAvailable(int iOnlinePlayers = -1);
+	bool IsAvailable();
 	bool Load();
 	std::shared_ptr<CCooldown> GetCooldown();
 	std::string GetCooldownText(bool bPlural);

--- a/src/playermanager.cpp
+++ b/src/playermanager.cpp
@@ -804,7 +804,7 @@ bool CPlayerManager::OnClientConnected(CPlayerSlot slot, uint64 xuid, const char
 	ResetPlayerFlags(slot.Get());
 
 	g_pMapVoteSystem->ClearPlayerInfo(slot.Get());
-	g_pMapVoteSystem->ClearInvalidNominations();
+	g_pMapVoteSystem->OnPlayerCountChange();
 
 	return true;
 }
@@ -829,7 +829,7 @@ void CPlayerManager::OnClientDisconnect(CPlayerSlot slot)
 	// One tick delay, to ensure player count decrements
 	CTimer::Create(0.01f, TIMERFLAG_MAP, []() {
 		g_pVoteManager->CheckRTVStatus();
-		g_pMapVoteSystem->ClearInvalidNominations();
+		g_pMapVoteSystem->OnPlayerCountChange();
 		return -1.0f;
 	});
 


### PR DESCRIPTION
PR adds two features to Map Vote system that are active when server is in "Low Population" (low player count) state:
- Nominations can ignore map cooldowns (other restrictions like min/max player count requirements still apply)
- Played maps don't go on cooldown (and don't trigger group cooldown)

These features function when server is at or below a player count threshold controlled by `cs2f_vote_lowpop_max_count` CVAR.
The nominations related feature is based on current player count, so nominations will become invalid once threshold player count is crossed. The "no cooldown on played maps" feature is based on maximum player count reached during map's playtime - cooldown does not get applied as long as maximum player count during the session was at most equal to the threshold player count.

Did very brief testing, so it might require more thorough testing on a live server to see if it works without issues.

**I'd also ask if different behavior introduced by this PR would need changes or additions to chat messages to tell players why their nomination got reset or why map doesn't go on cooldown.**